### PR TITLE
Add kratos integration

### DIFF
--- a/lib/charms/kratos/v0/kratos_endpoints.py
+++ b/lib/charms/kratos/v0/kratos_endpoints.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Interface library for sharing kratos endpoints.
+This library provides a Python API for both requesting and providing public and admin endpoints.
+## Getting Started
+To get started using the library, you need to fetch the library using `charmcraft`.
+```shell
+cd some-charm
+charmcraft fetch-lib charms.kratos.v0.kratos_endpoints
+```
+To use the library from the requirer side:
+In the `metadata.yaml` of the charm, add the following:
+```yaml
+requires:
+  kratos-endpoint-info:
+    interface: kratos_endpoints
+    limit: 1
+```
+Then, to initialise the library:
+```python
+from charms.kratos.v0.kratos_endpoints import (
+    KratosEndpointsRelationError,
+    KratosEndpointsRequirer,
+)
+Class SomeCharm(CharmBase):
+    def __init__(self, *args):
+        self.kratos_endpoints_relation = KratosEndpointsRequirer(self)
+        self.framework.observe(self.on.some_event_emitted, self.some_event_function)
+    def some_event_function():
+        # fetch the relation info
+        try:
+            kratos_data = self.kratos_endpoints_relation.get_kratos_endpoints()
+        except KratosEndpointsRelationError as error:
+            ...
+```
+"""
+
+import logging
+from typing import Dict, Optional
+
+from ops.charm import CharmBase, RelationCreatedEvent
+from ops.framework import EventBase, EventSource, Object, ObjectEvents
+
+# The unique Charmhub library identifier, never change it
+LIBID = "5868b36df1c04c90b33f5e5557327162"
+
+# Increment this major API version when introducing breaking changes
+LIBAPI = 0
+
+# Increment this PATCH version before using `charmcraft publish-lib` or reset
+# to 0 if you are raising the major API version
+LIBPATCH = 4
+
+RELATION_NAME = "kratos-endpoint-info"
+INTERFACE_NAME = "kratos_endpoints"
+logger = logging.getLogger(__name__)
+
+
+class KratosEndpointsRelationReadyEvent(EventBase):
+    """Event to notify the charm that the relation is ready."""
+
+
+class KratosEndpointsProviderEvents(ObjectEvents):
+    """Event descriptor for events raised by `KratosEndpointsProvider`."""
+
+    ready = EventSource(KratosEndpointsRelationReadyEvent)
+
+
+class KratosEndpointsProvider(Object):
+    """Provider side of the kratos-endpoint-info relation."""
+
+    on = KratosEndpointsProviderEvents()
+
+    def __init__(self, charm: CharmBase, relation_name: str = RELATION_NAME):
+        super().__init__(charm, relation_name)
+
+        self._charm = charm
+        self._relation_name = relation_name
+
+        events = self._charm.on[relation_name]
+        self.framework.observe(
+            events.relation_created, self._on_provider_endpoint_relation_created
+        )
+
+    def _on_provider_endpoint_relation_created(self, event: RelationCreatedEvent) -> None:
+        self.on.ready.emit()
+
+    def send_endpoint_relation_data(self, admin_endpoint: str, public_endpoint: str) -> None:
+        """Updates relation with endpoints info."""
+        if not self._charm.unit.is_leader():
+            return
+
+        relations = self.model.relations[self._relation_name]
+        endpoints_databag = {
+            "admin_endpoint": admin_endpoint,
+            "public_endpoint": public_endpoint,
+            "login_browser_endpoint": f"{public_endpoint}/self-service/login/browser",
+            "sessions_endpoint": f"{public_endpoint}/sessions/whoami",
+        }
+        for relation in relations:
+            relation.data[self._charm.app].update(endpoints_databag)
+
+
+class KratosEndpointsRelationError(Exception):
+    """Base class for the relation exceptions."""
+
+    pass
+
+
+class KratosEndpointsRelationMissingError(KratosEndpointsRelationError):
+    """Raised when the relation is missing."""
+
+    def __init__(self) -> None:
+        self.message = "Missing kratos-endpoint-info relation with kratos"
+        super().__init__(self.message)
+
+
+class KratosEndpointsRelationDataMissingError(KratosEndpointsRelationError):
+    """Raised when information is missing from the relation."""
+
+    def __init__(self, message: str) -> None:
+        self.message = message
+        super().__init__(self.message)
+
+
+class KratosEndpointsRequirer(Object):
+    """Requirer side of the kratos-endpoint-info relation."""
+
+    def __init__(self, charm: CharmBase, relation_name: str = RELATION_NAME):
+        super().__init__(charm, relation_name)
+        self.charm = charm
+        self.relation_name = relation_name
+
+    def get_kratos_endpoints(self) -> Optional[Dict]:
+        """Get the kratos endpoints."""
+        endpoints = self.model.relations[self.relation_name]
+        if len(endpoints) == 0:
+            raise KratosEndpointsRelationMissingError()
+
+        if not (app := endpoints[0].app):
+            raise KratosEndpointsRelationMissingError()
+
+        data = endpoints[0].data[app]
+
+        if not data:
+            logger.info("No relation data available.")
+            return
+
+        if "public_endpoint" not in data:
+            raise KratosEndpointsRelationDataMissingError(
+                "Missing public endpoint in kratos-endpoint-info relation data"
+            )
+
+        return data

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -18,5 +18,6 @@ resources:
     description: OCI image for oathkeeper container
     upstream-source: ghcr.io/canonical/oathkeeper:0.40.3
 requires:
-  ingress:
-    interface: ingress
+  kratos-endpoint-info:
+    interface: kratos_endpoints
+    limit: 1

--- a/src/charm.py
+++ b/src/charm.py
@@ -100,15 +100,16 @@ class OathkeeperCharm(CharmBase):
         return rendered
 
     def _get_kratos_endpoint_info(self, key: str) -> Optional[str]:
-        if self.model.relations[self._kratos_relation_name]:
-            try:
-                kratos_endpoints = self.kratos_endpoints.get_kratos_endpoints()
-                return kratos_endpoints[key]
-            except KratosEndpointsRelationDataMissingError:
-                logger.info("No kratos-endpoint-info relation data found")
-                return None
-        logger.info("Kratos relation not found")
-        return None
+        if not self.model.relations[self._kratos_relation_name]:
+            logger.info("Kratos relation not found")
+            return
+
+        try:
+            kratos_endpoints = self.kratos_endpoints.get_kratos_endpoints()
+            return kratos_endpoints[key]
+        except KratosEndpointsRelationDataMissingError:
+            logger.info("No kratos-endpoint-info relation data found")
+            return
 
     def _on_oathkeeper_pebble_ready(self, event: PebbleReadyEvent) -> None:
         """Event Handler for pebble ready event."""

--- a/templates/access-rules.yaml.j2
+++ b/templates/access-rules.yaml.j2
@@ -13,4 +13,4 @@
   errors:
     - handler: redirect
       config:
-        to: {{ kratos_login_url }}?return_to={{ return_to }}
+        to: {{ kratos_login_url | d("http://default-kratos-url/self-service/login/browser", true) }}?return_to={{ return_to }}

--- a/templates/oathkeeper.yaml.j2
+++ b/templates/oathkeeper.yaml.j2
@@ -17,7 +17,7 @@ errors:
     redirect:
       enabled: true
       config:
-        to: {{ kratos_login_url }}
+        to: {{ kratos_login_url | d("http://default-kratos-url/self-service/login/browser", true) }}
         when:
           - error:
               - unauthorized

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -10,6 +10,22 @@ CONTAINER_NAME = "oathkeeper"
 SERVICE_NAME = "oathkeeper"
 
 
+def setup_kratos_relation(harness: Harness) -> int:
+    relation_id = harness.add_relation("kratos-endpoint-info", "kratos")
+    harness.add_relation_unit(relation_id, "kratos/0")
+    harness.update_relation_data(
+        relation_id,
+        "kratos",
+        {
+            "admin_endpoint": f"http://kratos-admin-url:80/{harness.model.name}-kratos",
+            "public_endpoint": f"http://kratos-public-url:80/{harness.model.name}-kratos",
+            "login_browser_endpoint": f"http://kratos-public-url:80/{harness.model.name}-kratos/self-service/login/browser",
+            "sessions_endpoint": f"http://kratos-admin-url:80/{harness.model.name}-kratos/sessions/whoami",
+        },
+    )
+    return relation_id
+
+
 def test_pebble_container_can_connect(harness: Harness) -> None:
     harness.set_can_connect(CONTAINER_NAME, True)
     harness.charm.on.oathkeeper_pebble_ready.emit(CONTAINER_NAME)
@@ -26,7 +42,7 @@ def test_pebble_container_cannot_connect(harness: Harness) -> None:
     assert harness.charm.unit.status == WaitingStatus("Waiting to connect to Oathkeeper container")
 
 
-def test_update_container_config(harness: Harness) -> None:
+def test_update_container_config_without_kratos_relation(harness: Harness) -> None:
     harness.set_can_connect(CONTAINER_NAME, True)
 
     harness.charm.on.oathkeeper_pebble_ready.emit(CONTAINER_NAME)
@@ -51,7 +67,7 @@ def test_update_container_config(harness: Harness) -> None:
                 "redirect": {
                     "enabled": True,
                     "config": {
-                        "to": "http://kratos.testing.svc.cluster.local:4433/self-service/login/browser",
+                        "to": "http://default-kratos-url/self-service/login/browser",
                         "when": [
                             {
                                 "error": ["unauthorized", "forbidden"],
@@ -80,7 +96,98 @@ def test_update_container_config(harness: Harness) -> None:
             "cookie_session": {
                 "enabled": True,
                 "config": {
-                    "check_session_url": "http://kratos.testing.svc.cluster.local:4433/sessions/whoami",
+                    "check_session_url": "http://default-kratos-url/sessions/whoami",
+                    "preserve_path": True,
+                    "extra_from": "@this",
+                    "subject_from": "identity.id",
+                    "only": ["ory_kratos_session"],
+                },
+            },
+        },
+        "authorizers": {
+            "allow": {
+                "enabled": True,
+            },
+        },
+        "mutators": {
+            "noop": {
+                "enabled": True,
+            },
+            "header": {
+                "enabled": True,
+                "config": {
+                    "headers": {
+                        "X-User": "{{ print .Subject }}",
+                    },
+                },
+            },
+        },
+    }
+
+    container_config = container.pull(path="/etc/config/oathkeeper.yaml", encoding="utf-8")
+    assert yaml.safe_load(container_config.read()) == expected_config
+
+
+def test_update_container_config_with_kratos_relation(harness: Harness) -> None:
+    harness.set_can_connect(CONTAINER_NAME, True)
+    kratos_relation_id = setup_kratos_relation(harness)
+
+    harness.charm.on.oathkeeper_pebble_ready.emit(CONTAINER_NAME)
+    container = harness.model.unit.get_container(CONTAINER_NAME)
+
+    expected_config = {
+        "log": {
+            "level": "info",
+            "format": "json",
+        },
+        "serve": {
+            "api": {
+                "cors": {
+                    "enabled": True,
+                    "allowed_origins": ["*"],
+                },
+            },
+        },
+        "errors": {
+            "fallback": ["json"],
+            "handlers": {
+                "redirect": {
+                    "enabled": True,
+                    "config": {
+                        "to": harness.get_relation_data(kratos_relation_id, "kratos")[
+                            "login_browser_endpoint"
+                        ],
+                        "when": [
+                            {
+                                "error": ["unauthorized", "forbidden"],
+                                "request": {
+                                    "header": {
+                                        "accept": ["text/html"],
+                                    },
+                                },
+                            }
+                        ],
+                    },
+                },
+                "json": {
+                    "enabled": True,
+                },
+            },
+        },
+        "access_rules": {
+            "matching_strategy": "regexp",
+            "repositories": ["file:///etc/config/oathkeeper/access-rules.yaml"],
+        },
+        "authenticators": {
+            "noop": {
+                "enabled": True,
+            },
+            "cookie_session": {
+                "enabled": True,
+                "config": {
+                    "check_session_url": harness.get_relation_data(kratos_relation_id, "kratos")[
+                        "sessions_endpoint"
+                    ],
                     "preserve_path": True,
                     "extra_from": "@this",
                     "subject_from": "identity.id",


### PR DESCRIPTION
<!-- Fill out the sections that apply -->

## Issue
<!-- What issue is this PR trying to solve? -->
Oathkeeper is currently using default dummy values for kratos urls.

## Solution
<!-- A summary of the solution addressing the above issue -->
This PR adds integration with kratos through the `kratos_endpoints` library.

## Additional context
<!-- What is some specialized knowledge relevant to this project/technology -->
n/a

## Testing Instructions
<!-- What steps need to be taken to test this PR? -->
1. Pack and deploy oathkeeper charm
2. Deploy kratos (with the updated library)
3. `juju integrate kratos oathkeeper`
4. Deploy traefik and integrate with kratos:
```
juju deploy traefik-k8s traefik-public --channel edge
juju deploy traefik-k8s traefik-admin --channel edge

juju integrate traefik-public kratos:public-ingress
juju integrate traefik-admin kratos:admin-ingress
```
6. `juju show-unit oathkeeper/0` to check if the relation data was passed correctly.
Get the oathkeeper config file to confirm it was rendered correctly:
```
juju ssh oathkeeper/0 "PYTHONPATH=agents/unit-oathkeeper-0/charm/venv/ python3 -c '
from ops import pebble
p = pebble.Client(\"/charm/containers/oathkeeper/pebble.socket\")
f = p.pull(\"/etc/config/oathkeeper.yaml\")
print(f.read())
'"
```

## Release Notes
<!-- A digestable summary of the changes in this PR -->
added integration with kratos