### PR TITLE
Add actions

### DIFF
--- a/actions.yaml
+++ b/actions.yaml
@@ -3,8 +3,9 @@ list-rules:
   params:
     limit:
       description: The maximum amount of returned access rules
-      type: int
+      type: integer
       default: 20
+      minimum: 1
 get-rule:
   description: Get access rule content
   params:

--- a/actions.yaml
+++ b/actions.yaml
@@ -1,0 +1,14 @@
+list-rules:
+  description: List all access rules
+  params:
+    limit:
+      description: The maximum amount of returned access rules
+      type: int
+      default: 20
+get-rule:
+  description: Get access rule content
+  params:
+    rule-id:
+      description: Access rule id
+      type: string
+  required: ["rule-id"]

--- a/src/oathkeeper_cli.py
+++ b/src/oathkeeper_cli.py
@@ -37,7 +37,7 @@ class OathkeeperCLI:
             "--endpoint",
             self.oathkeeper_api_url,
             "--limit",
-            limit,
+            str(limit),
         ]
 
         stdout, _ = self._run_cmd(cmd)

--- a/src/oathkeeper_cli.py
+++ b/src/oathkeeper_cli.py
@@ -41,7 +41,6 @@ class OathkeeperCLI:
         ]
 
         stdout, _ = self._run_cmd(cmd)
-        logger.info(f"Fetched access rules: {stdout}")
         return json.loads(stdout)
 
     def get_rule(self, rule_id: str) -> Dict:
@@ -56,5 +55,4 @@ class OathkeeperCLI:
         ]
 
         stdout, _ = self._run_cmd(cmd)
-        logger.info(f"Fetched access rule by id: {stdout}")
         return json.loads(stdout)

--- a/src/oathkeeper_cli.py
+++ b/src/oathkeeper_cli.py
@@ -1,0 +1,60 @@
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""A helper class for interacting with the Oathkeeper CLI."""
+
+
+import json
+import logging
+from typing import Dict, List, Tuple, Union
+
+from ops.model import Container
+
+logger = logging.getLogger(__name__)
+
+
+class OathkeeperCLI:
+    """Helper object for running Oathkeeper CLI commands."""
+
+    def __init__(self, oathkeeper_api_url: str, container: Container):
+        self.oathkeeper_api_url = oathkeeper_api_url
+        self.container = container
+
+    def _run_cmd(
+        self, cmd: List[str], timeout: float = 20
+    ) -> Tuple[Union[str, bytes], Union[str, bytes]]:
+        logger.debug(f"Running cmd: {cmd}")
+        process = self.container.exec(cmd, timeout=timeout)
+        stdout, stderr = process.wait_output()
+        return stdout, stderr
+
+    def list_rules(self, limit: int) -> Dict:
+        """List access rules."""
+        cmd = [
+            "oathkeeper",
+            "rules",
+            "list",
+            "--endpoint",
+            self.oathkeeper_api_url,
+            "--limit",
+            limit,
+        ]
+
+        stdout, _ = self._run_cmd(cmd)
+        logger.info(f"Fetched access rules: {stdout}")
+        return json.loads(stdout)
+
+    def get_rule(self, rule_id: str) -> Dict:
+        """Get an access rule content by id."""
+        cmd = [
+            "oathkeeper",
+            "rules",
+            "get",
+            rule_id,
+            "--endpoint",
+            self.oathkeeper_api_url,
+        ]
+
+        stdout, _ = self._run_cmd(cmd)
+        logger.info(f"Fetched access rule by id: {stdout}")
+        return json.loads(stdout)

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -64,3 +64,16 @@ async def test_oathkeeper_scale_up(ops_test: OpsTest) -> None:
 
     assert ops_test.model.applications[APP_NAME].units[0].workload_status == "active"
     assert ops_test.model.applications[APP_NAME].units[1].workload_status == "active"
+
+
+async def test_list_rules(ops_test: OpsTest) -> None:
+    action = (
+        await ops_test.model.applications[APP_NAME]
+        .units[0]
+        .run_action(
+            "list-rules",
+        )
+    )
+    res = (await action.wait()).results
+
+    assert len(res) > 0

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,7 +1,7 @@
 # Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-from typing import Generator
+from typing import Dict, Generator
 from unittest.mock import MagicMock
 
 import pytest
@@ -26,3 +26,34 @@ def mocked_kubernetes_service_patcher(mocker: MockerFixture) -> MagicMock:
     mocked_service_patcher = mocker.patch("charm.KubernetesServicePatch")
     mocked_service_patcher.return_value = lambda x, y: None
     return mocked_service_patcher
+
+
+@pytest.fixture()
+def mocked_oathkeeper_is_running(mocker: MockerFixture) -> MagicMock:
+    return mocker.patch("charm.OathkeeperCharm._oathkeeper_service_is_running", return_value=True)
+
+
+@pytest.fixture()
+def oathkeeper_cli_rule() -> Dict:
+    return {
+        "id": "sample-rule:protected",
+        "authenticators": [{"handler": "cookie_session"}],
+        "authorizer": {"handler": "allow"},
+        "match": {"methods": ["GET", "POST"], "url": "http://some-url:8080/<.*>"},
+        "mutators": [{"handler": "header"}],
+    }
+
+
+@pytest.fixture()
+def mocked_get_rule(mocker: MockerFixture, oathkeeper_cli_rule: Dict) -> MagicMock:
+    mock = mocker.patch("charm.OathkeeperCLI.get_rule", return_value=oathkeeper_cli_rule)
+    return mock
+
+
+@pytest.fixture()
+def mocked_list_rules(mocker: MockerFixture, oathkeeper_cli_rule: Dict) -> MagicMock:
+    mock = mocker.patch(
+        "charm.OathkeeperCLI.list_rules",
+        return_value=[dict(oathkeeper_cli_rule, id=f"rule-{i}") for i in range(5)],
+    )
+    return mock


### PR DESCRIPTION
<!-- Fill out the sections that apply -->

## Issue
<!-- What issue is this PR trying to solve? -->
Oathkeeper doesn't have actions for listing and getting access rules. To get them, you need to execute commands on the container, which is not a desired user experience for the charms.

## Solution
<!-- A summary of the solution addressing the above issue -->
This PR adds `list-rules` and `get-rule` actions to the charm, which are the equivalents of:
```bash
kubectl exec -it oathkeeper-0 -c oathkeeper -n test-actions -- oathkeeper rules list --endpoint=http://localhost:4456/ --limit <limit>
kubectl exec -it oathkeeper-0 -c oathkeeper -n test-actions -- oathkeeper rules get <rule-name> --endpoint=http://localhost:4456/
```

## Additional context
<!-- What is some specialized knowledge relevant to this project/technology -->
n/a

## Testing Instructions
<!-- What steps need to be taken to test this PR? -->
1. Pack and deploy the charm.
2. Run actions:
- juju run oathkeeper/0 list-rules
- juju run oathkeeper/0 get-rule rule-id=sample-rule:protected
- juju run oathkeeper/0 get-rule rule-id=unexisting-rule

## Release Notes
<!-- A digestable summary of the changes in this PR -->
added actions