### PR TITLE
Store config file and access rules in configmaps

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -60,7 +60,7 @@ jobs:
           juju ssh oathkeeper/0 "PYTHONPATH=agents/unit-oathkeeper-0/charm/venv/ python3 -c '
           from ops import pebble
           p = pebble.Client(\"/charm/containers/oathkeeper/pebble.socket\")
-          f = p.pull(\"/etc/config/oathkeeper.yaml\")
+          f = p.pull(\"/etc/config/oathkeeper/oathkeeper.yaml\")
           print(f.read())
           '"
         if: failure()

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ lightkube-models
 jinja2
 jsonschema
 pydantic<2.0
+tenacity==8.2.2

--- a/src/charm.py
+++ b/src/charm.py
@@ -6,7 +6,6 @@
 
 """A Juju charm for Ory Oathkeeper."""
 
-import itertools
 import json
 import logging
 from typing import Dict, List, Optional
@@ -34,7 +33,17 @@ from charms.traefik_k8s.v2.ingress import (
     IngressPerAppRevokedEvent,
 )
 from jinja2 import Template
-from ops.charm import ActionEvent, CharmBase, HookEvent, PebbleReadyEvent, RelationChangedEvent
+from lightkube import Client
+from lightkube.resources.apps_v1 import StatefulSet
+from ops.charm import (
+    ActionEvent,
+    CharmBase,
+    HookEvent,
+    InstallEvent,
+    PebbleReadyEvent,
+    RelationChangedEvent,
+    RemoveEvent,
+)
 from ops.main import main
 from ops.model import (
     ActiveStatus,
@@ -45,7 +54,10 @@ from ops.model import (
     WaitingStatus,
 )
 from ops.pebble import ChangeError, Error, ExecError, Layer
+from tenacity import before_log, retry, stop_after_attempt, wait_exponential
 
+import config_map
+from config_map import AccessRulesConfigMap, OathkeeperConfigMap
 from oathkeeper_cli import OathkeeperCLI
 
 logger = logging.getLogger(__name__)
@@ -63,9 +75,12 @@ class OathkeeperCharm(CharmBase):
         self._container_name = "oathkeeper"
         self._service_name = "oathkeeper"
         self._container = self.unit.get_container(self._container_name)
-        self._oathkeeper_config_path = "/etc/config/oathkeeper.yaml"
-        self._oathkeeper_access_rules_path = "/etc/config/oathkeeper"
+        self._oathkeeper_config_dir_path = "/etc/config/oathkeeper"
+        self._oathkeeper_config_file_path = "/etc/config/oathkeeper/oathkeeper.yaml"
+        self._access_rules_dir_path = "/etc/config/access-rules"
         self._name = self.model.app.name
+        self._oathkeeper_config_map_name = "oathkeeper-config"
+        self._access_rules_config_map_name = "access-rules"
 
         self._kratos_relation_name = "kratos-endpoint-info"
         self._auth_proxy_relation_name = "auth-proxy"
@@ -86,6 +101,10 @@ class OathkeeperCharm(CharmBase):
             self, relation_name=self._kratos_relation_name
         )
 
+        self.client = Client(field_manager=self.app.name, namespace=self.model.name)
+        self.oathkeeper_configmap = OathkeeperConfigMap(self.client, self)
+        self.access_rules_configmap = AccessRulesConfigMap(self.client, self)
+
         self._oathkeeper_cli = OathkeeperCLI(
             f"http://localhost:{OATHKEEPER_API_PORT}",
             self._container,
@@ -100,6 +119,8 @@ class OathkeeperCharm(CharmBase):
         )
 
         self.framework.observe(self.on.oathkeeper_pebble_ready, self._on_oathkeeper_pebble_ready)
+        self.framework.observe(self.on.install, self._on_install)
+        self.framework.observe(self.on.remove, self._on_remove)
 
         self.framework.observe(
             self.auth_proxy.on.proxy_config_changed, self._on_auth_proxy_config_changed
@@ -138,7 +159,7 @@ class OathkeeperCharm(CharmBase):
                 self._service_name: {
                     "override": "replace",
                     "summary": "Oathkeeper Operator layer",
-                    "command": f"oathkeeper serve -c {self._oathkeeper_config_path}",
+                    "command": f"oathkeeper serve -c {self._oathkeeper_config_file_path}",
                     "startup": "enabled",
                 }
             },
@@ -182,6 +203,13 @@ class OathkeeperCharm(CharmBase):
     def _kratos_session_url(self) -> Optional[str]:
         return self._get_kratos_endpoint_info("sessions_endpoint")
 
+    def _get_all_access_rules_repositories(self) -> Optional[List]:
+        repositories = list()
+        if cm_access_rules := self.access_rules_configmap.get():
+            for key in cm_access_rules.keys():
+                repositories.append(f"{self._access_rules_dir_path}/{key}")
+        return repositories
+
     def _render_conf_file(self) -> str:
         """Render the Oathkeeper configuration file."""
         with open("templates/oathkeeper.yaml.j2", "r") as file:
@@ -190,16 +218,19 @@ class OathkeeperCharm(CharmBase):
         rendered = template.render(
             kratos_session_url=self._kratos_session_url,
             kratos_login_url=self._kratos_login_url,
-            access_rules=self._get_all_access_rules_locations(),
+            access_rules=self._get_all_access_rules_repositories(),
         )
         return rendered
 
-    def _push_oathkeeper_config(self) -> None:
-        self._container.push(
-            self._oathkeeper_config_path,
-            self._render_conf_file(),
-            make_dirs=True,
-        )
+    @retry(
+        wait=wait_exponential(multiplier=3, min=1, max=10),
+        stop=stop_after_attempt(5),
+        reraise=True,
+        before=before_log(logger, logging.DEBUG),
+    )
+    def _update_config(self) -> None:
+        conf = self._render_conf_file()
+        self.oathkeeper_configmap.update({"oathkeeper.yaml": conf})
 
     def _get_kratos_endpoint_info(self, key: str) -> Optional[str]:
         if not self.model.relations[self._kratos_relation_name]:
@@ -253,9 +284,51 @@ class OathkeeperCharm(CharmBase):
         key = self._auth_proxy_relation_peer_data_key(relation_id)
         return self._pop_peer_data(key)
 
+    def _patch_statefulset(self, mount_path: str, name: str, config_map_name: str) -> None:
+        pod_spec_patch = {
+            "containers": [
+                {
+                    "name": self._container_name,
+                    "volumeMounts": [
+                        {
+                            "mountPath": mount_path,
+                            "name": name,
+                            "readOnly": True,
+                        },
+                    ],
+                },
+            ],
+            "volumes": [
+                {
+                    "name": name,
+                    "configMap": {"name": config_map_name},
+                },
+            ],
+        }
+        patch = {"spec": {"template": {"spec": pod_spec_patch}}}
+        self.client.patch(StatefulSet, name=self.meta.name, namespace=self.model.name, obj=patch)
+
+    def _on_install(self, event: InstallEvent) -> None:
+        if not self.unit.is_leader():
+            return
+
+        config_map.create_all()
+        self._update_config()
+
     def _on_oathkeeper_pebble_ready(self, event: PebbleReadyEvent) -> None:
         """Event Handler for pebble ready event."""
+        self._patch_statefulset(
+            mount_path=self._oathkeeper_config_dir_path,
+            name="config",
+            config_map_name=self._oathkeeper_config_map_name,
+        )
         self._handle_status_update_config(event)
+
+    def _on_remove(self, event: RemoveEvent) -> None:
+        if not self.unit.is_leader():
+            return
+
+        config_map.delete_all()
 
     def _on_kratos_relation_changed(self, event: RelationChangedEvent) -> None:
         self._handle_status_update_config(event)
@@ -278,9 +351,8 @@ class OathkeeperCharm(CharmBase):
 
         self.unit.status = MaintenanceStatus("Configuring the container")
 
+        self._update_config()
         self._container.add_layer(self._container_name, self._oathkeeper_layer, combine=True)
-
-        self._push_oathkeeper_config()
 
         try:
             self._container.restart(self._container_name)
@@ -359,7 +431,7 @@ class OathkeeperCharm(CharmBase):
             event.defer()
             return
 
-        access_rules_locations = list()
+        access_rules_filenames = list()
         for rule_type in ("allow", "deny"):
             rules = self._render_access_rules(
                 rule_type=rule_type,
@@ -369,17 +441,23 @@ class OathkeeperCharm(CharmBase):
             )
 
             if rules:
-                # Push the rules to the container
-                filename = f"{self._oathkeeper_access_rules_path}/access-rules-{event.relation_app_name}-{rule_type}.json"
-                self._container.push(filename, str(rules), make_dirs=True)
-                access_rules_locations.append(filename)
+                cm_name = f"access-rules-{event.relation_app_name}-{rule_type}.json"
+                patch = {"data": {cm_name: str(rules)}}
+                self.access_rules_configmap.patch(patch=patch, cm_name="access-rules")
+                access_rules_filenames.append(cm_name)
+
+            self._patch_statefulset(
+                mount_path=self._access_rules_dir_path,
+                name="access-rules",
+                config_map_name=self._access_rules_config_map_name,
+            )
 
         self._set_auth_proxy_relation_peer_data(
-            event.relation_id, dict(access_rules_locations=access_rules_locations)
+            event.relation_id, dict(access_rules_filenames=access_rules_filenames)
         )
 
         try:
-            self._push_oathkeeper_config()
+            self._update_config()
         except Error as e:
             logger.error(f"Failed to set new config: {e}")
             self.unit.status = BlockedStatus("Failed to set new config, see logs")
@@ -455,22 +533,6 @@ class OathkeeperCharm(CharmBase):
 
         return rules
 
-    def _get_all_access_rules_locations(self) -> Optional[List]:
-        if not self.model.relations[self._auth_proxy_relation_name]:
-            logger.info("No auth-proxy relations found")
-            return None
-
-        relation_locations = list()
-        for relation in self.model.relations[self._auth_proxy_relation_name]:
-            peer_data = self._get_auth_proxy_relation_peer_data(relation.id)
-            if peer_data:
-                relation_locations.append(peer_data["access_rules_locations"])
-
-        # Get a consolidated list of locations
-        access_rules_locations = itertools.chain.from_iterable(relation_locations)
-
-        return access_rules_locations
-
     def _remove_auth_proxy_configuration(self, event: AuthProxyConfigRemovedEvent) -> None:
         """Remove the auth-proxy-related config for a given relation."""
         if not self._peers:
@@ -483,12 +545,10 @@ class OathkeeperCharm(CharmBase):
             logger.error("No access rules locations found in peer data")
             return
 
-        for file in peer_data["access_rules_locations"]:
-            self._container.remove_path(file)
-
+        self.access_rules_configmap.pop_data(keys=peer_data["access_rules_filenames"])
         self._pop_auth_proxy_relation_peer_data(event.relation_id)
 
-        self._push_oathkeeper_config()
+        self._update_config()
         self.forward_auth.update_forward_auth_config(self._forward_auth_config)
 
 

--- a/src/config_map.py
+++ b/src/config_map.py
@@ -1,0 +1,138 @@
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""A helper class for managing the configMaps holding the oathkeeper config."""
+
+import logging
+from typing import Dict, List
+
+from lightkube import ApiError, Client
+from lightkube.models.meta_v1 import ObjectMeta
+from lightkube.resources.core_v1 import ConfigMap
+from ops.charm import CharmBase
+
+logger = logging.getLogger(__name__)
+
+
+class ConfigMapManager:
+    """A helper class for managing configMaps."""
+
+    configmaps = {}
+
+    @classmethod
+    def create_all(cls) -> None:
+        """Create all the configMaps."""
+        for cm in cls.configmaps.values():
+            cm.create()
+
+    @classmethod
+    def delete_all(cls) -> None:
+        """Delete all the configMaps."""
+        for cm in cls.configmaps.values():
+            cm.delete()
+
+    @classmethod
+    def register(cls, cm: "ConfigMapBase") -> None:
+        """Register a configMap."""
+        cls.configmaps[f"{cm.namespace}_{cm.name}"] = cm
+
+
+class ConfigMapBase:
+    """Base class for managing a configMap."""
+
+    def __init__(self, configmap_name: str, client: Client, charm: CharmBase) -> None:
+        self.name = configmap_name
+        self._client = client
+        self._charm = charm
+        ConfigMapManager.register(self)
+
+    @property
+    def namespace(self):
+        """The namespace of the ConfigMap."""
+        return self._charm.model.name
+
+    def create(self):
+        """Create the configMap."""
+        try:
+            self._client.get(ConfigMap, self.name, namespace=self.namespace)
+            return
+        except ApiError:
+            pass
+
+        cm = ConfigMap(
+            apiVersion="v1",
+            kind="ConfigMap",
+            metadata=ObjectMeta(
+                name=self.name,
+                namespace=self.namespace,
+                labels={
+                    "juju-app-name": self._charm.app.name,
+                    "app.kubernetes.io/managed-by": "juju",
+                },
+            ),
+        )
+        self._client.create(cm)
+
+    def update(self, data: Dict):
+        """Update the configMap."""
+        try:
+            cm = self._client.get(ConfigMap, self.name, namespace=self.namespace)
+        except ApiError:
+            return
+        cm.data = data
+        self._client.replace(cm)
+
+    def patch(self, patch: Dict, cm_name: str):
+        """Patch the configMap."""
+        self._client.patch(ConfigMap, name=cm_name, namespace=self.namespace, obj=patch)
+
+    def pop_data(self, keys: List[str]):
+        """Pop data from the configMap."""
+        try:
+            cm = self._client.get(ConfigMap, self.name, namespace=self.namespace)
+        except ApiError:
+            return
+
+        for key in keys:
+            cm.data.pop(key)
+
+        self._client.replace(cm)
+
+    def get(self):
+        """Get the configMap."""
+        try:
+            cm = self._client.get(ConfigMap, self.name, namespace=self.namespace)
+        except ApiError:
+            return {}
+        return cm.data
+
+    def delete(self):
+        """Delete the configMap."""
+        try:
+            self._client.delete(ConfigMap, self.name, namespace=self.namespace)
+        except ApiError:
+            raise ValueError
+
+
+class OathkeeperConfigMap(ConfigMapBase):
+    """Class for managing the Oathkeeper config configMap."""
+
+    def __init__(self, client: Client, charm: CharmBase) -> None:
+        super().__init__("oathkeeper-config", client, charm)
+
+
+class AccessRulesConfigMap(ConfigMapBase):
+    """Class for managing the Oathkeeper access rules configMap."""
+
+    def __init__(self, client: Client, charm: CharmBase) -> None:
+        super().__init__("access-rules", client, charm)
+
+
+def create_all():
+    """Create all the register configMaps."""
+    ConfigMapManager.create_all()
+
+
+def delete_all():
+    """Delete all the register configMaps."""
+    ConfigMapManager.delete_all()

--- a/src/config_map.py
+++ b/src/config_map.py
@@ -86,7 +86,7 @@ class ConfigMapBase:
         """Patch the configMap."""
         self._client.patch(ConfigMap, name=cm_name, namespace=self.namespace, obj=patch)
 
-    def pop_data(self, keys: List[str]):
+    def pop(self, keys: List[str]):
         """Pop data from the configMap."""
         try:
             cm = self._client.get(ConfigMap, self.name, namespace=self.namespace)

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,14 @@
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import os
+
+import pytest
+from lightkube import Client, KubeConfig
+
+KUBECONFIG = os.environ.get("TESTING_KUBECONFIG", "~/.kube/config")
+
+
+@pytest.fixture(scope="module")
+def client() -> Client:
+    return Client(config=KubeConfig.from_file(KUBECONFIG))

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -43,6 +43,7 @@ async def test_build_and_deploy(ops_test: OpsTest) -> None:
 
     await ops_test.model.wait_for_idle(
         raise_on_blocked=False,
+        raise_on_error=False,
         status="active",
         timeout=1000,
     )

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -33,6 +33,48 @@ def mocked_oathkeeper_is_running(mocker: MockerFixture) -> MagicMock:
     return mocker.patch("charm.OathkeeperCharm._oathkeeper_service_is_running", return_value=True)
 
 
+@pytest.fixture(autouse=True)
+def lk_client(mocker: MockerFixture) -> None:
+    mock_lightkube = mocker.patch("charm.Client", autospec=True)
+    return mock_lightkube.return_value
+
+
+@pytest.fixture(autouse=True)
+def mocked_oathkeeper_configmap(mocker: MockerFixture) -> MagicMock:
+    mock = mocker.patch("charm.OathkeeperConfigMap", autospec=True)
+    return mock.return_value
+
+
+@pytest.fixture(autouse=True)
+def mocked_access_rules_configmap(mocker: MockerFixture) -> MagicMock:
+    mock = mocker.patch("charm.AccessRulesConfigMap", autospec=True)
+    return mock.return_value
+
+
+@pytest.fixture()
+def mocked_get_repositories(mocker: MockerFixture) -> MagicMock:
+    repositories = [
+        "/etc/config/access-rules/access-rules-requirer-allow.json",
+        "/etc/config/access-rules/access-rules-requirer-deny.json",
+    ]
+    return mocker.patch(
+        "charm.OathkeeperCharm._get_all_access_rules_repositories", return_value=repositories
+    )
+
+
+@pytest.fixture()
+def mocked_get_repositories_for_multiple_relations(mocker: MockerFixture) -> MagicMock:
+    repositories = [
+        "/etc/config/access-rules/access-rules-requirer-allow.json",
+        "/etc/config/access-rules/access-rules-requirer-deny.json",
+        "/etc/config/access-rules/access-rules-other-requirer-allow.json",
+        "/etc/config/access-rules/access-rules-other-requirer-deny.json",
+    ]
+    return mocker.patch(
+        "charm.OathkeeperCharm._get_all_access_rules_repositories", return_value=repositories
+    )
+
+
 @pytest.fixture()
 def oathkeeper_cli_rule() -> Dict:
     return {

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -663,11 +663,11 @@ def test_access_rules_pop_from_configmap_on_auth_proxy_config_removed(
     harness.set_can_connect(CONTAINER_NAME, True)
     peer_relation_id, _ = setup_peer_relation(harness)
     relation_id, app_name = setup_auth_proxy_relation(harness)
-    harness.charm.access_rules_configmap.pop_data = mocked_handle = Mock(return_value=None)
+    harness.charm.access_rules_configmap.pop = mocked_handle = Mock(return_value=None)
 
     harness.remove_relation(relation_id)
 
-    configmap_keys = mocked_access_rules_configmap.pop_data.call_args_list[0][1]["keys"]
+    configmap_keys = mocked_access_rules_configmap.pop.call_args_list[0][1]["keys"]
     mocked_handle.assert_called_with(keys=configmap_keys)
 
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -4,7 +4,7 @@
 import json
 import logging
 from typing import Optional, Tuple
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, Mock
 
 import pytest
 import yaml
@@ -13,8 +13,8 @@ from ops.model import ActiveStatus, WaitingStatus
 from ops.pebble import ExecError
 from ops.testing import Harness
 
-ACCESS_RULES_PATH = "/etc/config/oathkeeper"
-CONFIG_FILE_PATH = "/etc/config/oathkeeper.yaml"
+ACCESS_RULES_PATH = "/etc/config/access-rules"
+CONFIG_FILE_PATH = "/etc/config/oathkeeper/oathkeeper.yaml"
 CONTAINER_NAME = "oathkeeper"
 SERVICE_NAME = "oathkeeper"
 
@@ -147,11 +147,19 @@ def test_ingress_relation_revoked(harness: Harness, caplog: pytest.LogCaptureFix
     assert "This app no longer has ingress" in caplog.record_tuples[2]
 
 
-def test_update_container_config_without_kratos_relation(harness: Harness) -> None:
+def test_on_pebble_ready_lk_called(harness: Harness, lk_client: MagicMock) -> None:
+    container = harness.model.unit.get_container(CONTAINER_NAME)
+    harness.charm.on.oathkeeper_pebble_ready.emit(container)
+
+    lk_client.patch.assert_called_once()
+
+
+def test_update_container_config_without_kratos_relation(
+    harness: Harness, mocked_oathkeeper_configmap: MagicMock
+) -> None:
     harness.set_can_connect(CONTAINER_NAME, True)
 
     harness.charm.on.oathkeeper_pebble_ready.emit(CONTAINER_NAME)
-    container = harness.model.unit.get_container(CONTAINER_NAME)
 
     with open("templates/oathkeeper.yaml.j2", "r") as file:
         template = Template(file.read())
@@ -161,15 +169,16 @@ def test_update_container_config_without_kratos_relation(harness: Harness) -> No
         kratos_login_url=None,
     )
 
-    container_config = container.pull(path=CONFIG_FILE_PATH, encoding="utf-8")
-    assert yaml.safe_load(container_config.read()) == yaml.safe_load(expected_config)
+    configmap = mocked_oathkeeper_configmap.update.call_args_list[-1][0][0]
+    config = configmap["oathkeeper.yaml"]
+    assert yaml.safe_load(expected_config) == yaml.safe_load(config)
 
 
-def test_update_container_config_with_kratos_relation(harness: Harness) -> None:
+def test_update_container_config_with_kratos_relation(
+    harness: Harness, mocked_oathkeeper_configmap: MagicMock
+) -> None:
     harness.set_can_connect(CONTAINER_NAME, True)
     kratos_relation_id = setup_kratos_relation(harness)
-
-    container = harness.model.unit.get_container(CONTAINER_NAME)
 
     with open("templates/oathkeeper.yaml.j2", "r") as file:
         template = Template(file.read())
@@ -183,8 +192,9 @@ def test_update_container_config_with_kratos_relation(harness: Harness) -> None:
         ],
     )
 
-    container_config = container.pull(path=CONFIG_FILE_PATH, encoding="utf-8")
-    assert yaml.safe_load(container_config.read()) == yaml.safe_load(expected_config)
+    configmap = mocked_oathkeeper_configmap.update.call_args_list[-1][0][0]
+    config = configmap["oathkeeper.yaml"]
+    assert yaml.safe_load(expected_config) == yaml.safe_load(config)
 
 
 def test_on_pebble_ready_correct_plan(harness: Harness) -> None:
@@ -198,12 +208,22 @@ def test_on_pebble_ready_correct_plan(harness: Harness) -> None:
                 "override": "replace",
                 "summary": "Oathkeeper Operator layer",
                 "startup": "enabled",
-                "command": "oathkeeper serve -c /etc/config/oathkeeper.yaml",
+                "command": f"oathkeeper serve -c {CONFIG_FILE_PATH}",
             }
         }
     }
     updated_plan = harness.get_container_pebble_plan(CONTAINER_NAME).to_dict()
     assert expected_plan == updated_plan
+
+
+def test_on_pebble_ready_statefulset_patched(harness: Harness) -> None:
+    harness.set_can_connect(CONTAINER_NAME, True)
+    harness.charm._patch_statefulset = mocked_handle = Mock(return_value=None)
+
+    container = harness.model.unit.get_container(CONTAINER_NAME)
+    harness.charm.on.oathkeeper_pebble_ready.emit(container)
+
+    assert mocked_handle.called
 
 
 def test_list_rules_action(
@@ -321,9 +341,10 @@ def test_no_peer_relation_on_auth_proxy_config_changed(
 def test_config_file_updated_with_access_rules_locations(
     harness: Harness,
     mocked_oathkeeper_is_running: MagicMock,
+    mocked_oathkeeper_configmap: MagicMock,
+    mocked_get_repositories: MagicMock,
 ) -> None:
     harness.set_can_connect(CONTAINER_NAME, True)
-    container = harness.model.unit.get_container(CONTAINER_NAME)
     setup_peer_relation(harness)
 
     relation_id, app_name = setup_auth_proxy_relation(harness)
@@ -340,16 +361,19 @@ def test_config_file_updated_with_access_rules_locations(
         ],
     )
 
-    container_config = container.pull(path=CONFIG_FILE_PATH, encoding="utf-8")
-    assert yaml.safe_load(container_config.read()) == yaml.safe_load(expected_config)
+    configmap = mocked_oathkeeper_configmap.update.call_args_list[-1][0][0]
+    container_config = configmap["oathkeeper.yaml"]
+
+    assert yaml.safe_load(container_config) == yaml.safe_load(expected_config)
 
 
 def test_config_file_updated_when_multiple_auth_proxy_relations(
     harness: Harness,
     mocked_oathkeeper_is_running: MagicMock,
+    mocked_oathkeeper_configmap: MagicMock,
+    mocked_get_repositories_for_multiple_relations: MagicMock,
 ) -> None:
     harness.set_can_connect(CONTAINER_NAME, True)
-    container = harness.model.unit.get_container(CONTAINER_NAME)
 
     peer_relation_id, _ = setup_peer_relation(harness)
 
@@ -372,16 +396,17 @@ def test_config_file_updated_when_multiple_auth_proxy_relations(
         ],
     )
 
-    container_config = container.pull(path=CONFIG_FILE_PATH, encoding="utf-8")
-    assert yaml.safe_load(container_config.read()) == yaml.safe_load(expected_config)
+    configmap = mocked_oathkeeper_configmap.update.call_args_list[-1][0][0]
+    container_config = configmap["oathkeeper.yaml"]
+    assert yaml.safe_load(container_config) == yaml.safe_load(expected_config)
 
 
 def test_allow_access_rules_rendering(
     harness: Harness,
     mocked_oathkeeper_is_running: MagicMock,
+    mocked_access_rules_configmap: MagicMock,
 ) -> None:
     harness.set_can_connect(CONTAINER_NAME, True)
-    container = harness.model.unit.get_container(CONTAINER_NAME)
     setup_peer_relation(harness)
 
     relation_id, app_name = setup_auth_proxy_relation(harness)
@@ -411,33 +436,33 @@ def test_allow_access_rules_rendering(
         },
     ]
 
-    container_allow_rules = container.pull(
-        path=f"{ACCESS_RULES_PATH}/access-rules-{app_name}-allow.json", encoding="utf-8"
-    )
-    assert container_allow_rules.read() == str(expected_allow_rules)
+    configmap_data = mocked_access_rules_configmap.patch.call_args_list[0][1]
+    container_allow_rules = configmap_data["patch"]["data"][f"access-rules-{app_name}-allow.json"]
+    assert str(expected_allow_rules) == container_allow_rules
 
 
 def test_allow_access_rules_not_rendered_when_no_allowed_endpoints_provided(
     harness: Harness,
     mocked_oathkeeper_is_running: MagicMock,
+    mocked_access_rules_configmap: MagicMock,
 ) -> None:
     harness.set_can_connect(CONTAINER_NAME, True)
     setup_peer_relation(harness)
 
     relation_id, app_name = setup_auth_proxy_relation_without_allowed_endpoints(harness)
 
-    assert not (
-        harness.get_filesystem_root(CONTAINER_NAME)
-        / f"{ACCESS_RULES_PATH}/access-rules-{app_name}-allow.json"
-    ).exists()
+    configmap_data = mocked_access_rules_configmap.patch.call_args_list[0][1]
+    container_allow_rules = configmap_data["patch"]["data"]
+
+    assert f"access-rules-{app_name}-allow.json" not in container_allow_rules
 
 
 def test_allow_access_rules_rendering_when_auth_proxy_config_changed(
     harness: Harness,
     mocked_oathkeeper_is_running: MagicMock,
+    mocked_access_rules_configmap: MagicMock,
 ) -> None:
     harness.set_can_connect(CONTAINER_NAME, True)
-    container = harness.model.unit.get_container(CONTAINER_NAME)
     setup_peer_relation(harness)
 
     relation_id, app_name = setup_auth_proxy_relation(harness)
@@ -476,18 +501,17 @@ def test_allow_access_rules_rendering_when_auth_proxy_config_changed(
         },
     ]
 
-    container_allow_rules = container.pull(
-        path=f"{ACCESS_RULES_PATH}/access-rules-{app_name}-allow.json", encoding="utf-8"
-    )
-    assert container_allow_rules.read() == str(expected_allow_rules)
+    configmap_data = mocked_access_rules_configmap.patch.call_args_list[2][1]
+    container_allow_rules = configmap_data["patch"]["data"][f"access-rules-{app_name}-allow.json"]
+    assert str(expected_allow_rules) == container_allow_rules
 
 
 def test_deny_access_rules_rendering_when_single_protected_url_provided(
     harness: Harness,
     mocked_oathkeeper_is_running: MagicMock,
+    mocked_access_rules_configmap: MagicMock,
 ) -> None:
     harness.set_can_connect(CONTAINER_NAME, True)
-    container = harness.model.unit.get_container(CONTAINER_NAME)
     setup_peer_relation(harness)
 
     relation_id, app_name = setup_auth_proxy_relation(harness)
@@ -506,18 +530,17 @@ def test_deny_access_rules_rendering_when_single_protected_url_provided(
         },
     ]
 
-    container_deny_rules = container.pull(
-        path=f"{ACCESS_RULES_PATH}/access-rules-{app_name}-deny.json", encoding="utf-8"
-    )
-    assert container_deny_rules.read() == str(expected_deny_rules)
+    configmap_data = mocked_access_rules_configmap.patch.call_args_list[1][1]
+    container_deny_rules = configmap_data["patch"]["data"][f"access-rules-{app_name}-deny.json"]
+    assert str(expected_deny_rules) == container_deny_rules
 
 
 def test_deny_access_rules_rendering_when_multiple_protected_urls_provided(
     harness: Harness,
     mocked_oathkeeper_is_running: MagicMock,
+    mocked_access_rules_configmap: MagicMock,
 ) -> None:
     harness.set_can_connect(CONTAINER_NAME, True)
-    container = harness.model.unit.get_container(CONTAINER_NAME)
     setup_peer_relation(harness)
 
     relation_id, app_name = setup_auth_proxy_relation(harness)
@@ -555,18 +578,17 @@ def test_deny_access_rules_rendering_when_multiple_protected_urls_provided(
         },
     ]
 
-    container_deny_rules = container.pull(
-        path=f"{ACCESS_RULES_PATH}/access-rules-{app_name}-deny.json", encoding="utf-8"
-    )
-    assert container_deny_rules.read() == str(expected_deny_rules)
+    configmap_data = mocked_access_rules_configmap.patch.call_args_list[3][1]
+    container_deny_rules = configmap_data["patch"]["data"][f"access-rules-{app_name}-deny.json"]
+    assert str(expected_deny_rules) == container_deny_rules
 
 
 def test_all_endpoints_protected_when_no_allowed_endpoints_provided(
     harness: Harness,
     mocked_oathkeeper_is_running: MagicMock,
+    mocked_access_rules_configmap: MagicMock,
 ) -> None:
     harness.set_can_connect(CONTAINER_NAME, True)
-    container = harness.model.unit.get_container(CONTAINER_NAME)
     setup_peer_relation(harness)
 
     relation_id, app_name = setup_auth_proxy_relation_without_allowed_endpoints(harness)
@@ -585,10 +607,10 @@ def test_all_endpoints_protected_when_no_allowed_endpoints_provided(
         },
     ]
 
-    container_deny_rules = container.pull(
-        path=f"{ACCESS_RULES_PATH}/access-rules-{app_name}-deny.json", encoding="utf-8"
-    )
-    assert container_deny_rules.read() == str(expected_deny_rules)
+    configmap_data = mocked_access_rules_configmap.patch.call_args_list[0][1]
+    container_deny_rules = configmap_data["patch"]["data"][f"access-rules-{app_name}-deny.json"]
+
+    assert str(expected_deny_rules) == container_deny_rules
 
 
 def test_peer_data_set_on_auth_proxy_config_changed(
@@ -601,7 +623,7 @@ def test_peer_data_set_on_auth_proxy_config_changed(
     relation_id, _ = setup_auth_proxy_relation(harness)
     auth_proxy_peer_id = f"auth_proxy_{relation_id}"
 
-    peer_data = '{"access_rules_locations": ["/etc/config/oathkeeper/access-rules-requirer-allow.json", "/etc/config/oathkeeper/access-rules-requirer-deny.json"]}'
+    peer_data = '{"access_rules_filenames": ["access-rules-requirer-allow.json", "access-rules-requirer-deny.json"]}'
     assert harness.get_relation_data(peer_relation_id, harness.charm.app) == {
         auth_proxy_peer_id: peer_data
     }
@@ -633,24 +655,20 @@ def test_peer_data_pop_on_auth_proxy_config_removed(
     assert harness.get_relation_data(peer_relation_id, harness.charm.app) == {}
 
 
-def test_access_rules_files_removed_on_auth_proxy_config_removed(
+def test_access_rules_pop_from_configmap_on_auth_proxy_config_removed(
     harness: Harness,
     mocked_oathkeeper_is_running: MagicMock,
+    mocked_access_rules_configmap: MagicMock,
 ) -> None:
     harness.set_can_connect(CONTAINER_NAME, True)
-
     peer_relation_id, _ = setup_peer_relation(harness)
     relation_id, app_name = setup_auth_proxy_relation(harness)
+    harness.charm.access_rules_configmap.pop_data = mocked_handle = Mock(return_value=None)
 
     harness.remove_relation(relation_id)
 
-    root_dir = harness.get_filesystem_root(CONTAINER_NAME)
-    locations = [
-        f"{ACCESS_RULES_PATH}/access-rules-{app_name}-allow.json",
-        f"{ACCESS_RULES_PATH}/access-rules-{app_name}-deny.json",
-    ]
-    for location in locations:
-        assert not (root_dir / location).exists()
+    configmap_keys = mocked_access_rules_configmap.pop_data.call_args_list[0][1]["keys"]
+    mocked_handle.assert_called_with(keys=configmap_keys)
 
 
 def test_peer_data_when_multiple_auth_proxy_relations(
@@ -668,8 +686,8 @@ def test_peer_data_when_multiple_auth_proxy_relations(
     )
     other_requirer_auth_proxy_peer_id = f"auth_proxy_{other_requirer_relation_id}"
 
-    requirer_peer_data = '{"access_rules_locations": ["/etc/config/oathkeeper/access-rules-requirer-allow.json", "/etc/config/oathkeeper/access-rules-requirer-deny.json"]}'
-    other_requirer_peer_data = '{"access_rules_locations": ["/etc/config/oathkeeper/access-rules-other-requirer-allow.json", "/etc/config/oathkeeper/access-rules-other-requirer-deny.json"]}'
+    requirer_peer_data = '{"access_rules_filenames": ["access-rules-requirer-allow.json", "access-rules-requirer-deny.json"]}'
+    other_requirer_peer_data = '{"access_rules_filenames": ["access-rules-other-requirer-allow.json", "access-rules-other-requirer-deny.json"]}'
 
     assert harness.get_relation_data(peer_relation_id, harness.charm.app) == {
         requirer_auth_proxy_peer_id: requirer_peer_data,

--- a/tests/unit/test_config_map.py
+++ b/tests/unit/test_config_map.py
@@ -90,14 +90,14 @@ def test_config_map_patch(
 
 
 @pytest.mark.parametrize("cls", (OathkeeperConfigMap, AccessRulesConfigMap))
-def test_config_map_pop_data(
+def test_config_map_pop(
     lk_client: MagicMock,
     cls: ConfigMapBase,
     mocked_charm: MagicMock,
 ) -> None:
     cm = cls(lk_client, mocked_charm)
 
-    cm.pop_data(keys=["some-key"])
+    cm.pop(keys=["some-key"])
 
     assert lk_client.replace.called
 

--- a/tests/unit/test_config_map.py
+++ b/tests/unit/test_config_map.py
@@ -1,0 +1,163 @@
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+from unittest.mock import MagicMock
+
+import pytest
+from httpx import Response
+from lightkube import ApiError
+from pytest_mock import MockerFixture
+
+from charm import OathkeeperCharm
+from config_map import AccessRulesConfigMap, ConfigMapBase, ConfigMapManager, OathkeeperConfigMap
+
+
+@pytest.fixture
+def mocked_charm() -> MagicMock:
+    mock = MagicMock(spec=OathkeeperCharm)
+    mock.model.name = "namespace"
+    return mock
+
+
+def test_create_all(lk_client: MagicMock, mocker: MockerFixture, mocked_charm: MagicMock) -> None:
+    mock = mocker.patch("config_map.ConfigMapBase.create")
+    OathkeeperConfigMap(lk_client, mocked_charm)
+    AccessRulesConfigMap(lk_client, mocked_charm)
+
+    ConfigMapManager.create_all()
+
+    assert mock.call_count == 2
+
+
+def test_delete_all(lk_client: MagicMock, mocker: MockerFixture, mocked_charm: MagicMock) -> None:
+    mock = mocker.patch("config_map.ConfigMapBase.delete")
+    OathkeeperConfigMap(lk_client, mocked_charm)
+    AccessRulesConfigMap(lk_client, mocked_charm)
+
+    ConfigMapManager.delete_all()
+
+    assert mock.call_count == 2
+
+
+@pytest.mark.parametrize("cls", (OathkeeperConfigMap, AccessRulesConfigMap))
+def test_config_map_create(
+    lk_client: MagicMock, cls: ConfigMapBase, mocked_charm: MagicMock
+) -> None:
+    resp = Response(status_code=403, json={"message": "Forbidden", "code": 403})
+    lk_client.get.side_effect = ApiError(response=resp)
+    cm = cls(lk_client, mocked_charm)
+
+    cm.create()
+
+    assert lk_client.create.call_args[0][0].metadata.name == cm.name
+
+
+@pytest.mark.parametrize("cls", (OathkeeperConfigMap, AccessRulesConfigMap))
+def test_create_map_already_exists(
+    lk_client: MagicMock, cls: ConfigMapBase, mocked_charm: MagicMock
+) -> None:
+    cm = cls(lk_client, mocked_charm)
+
+    cm.create()
+
+    assert lk_client.get.called
+    assert not lk_client.create.called
+
+
+@pytest.mark.parametrize("cls", (OathkeeperConfigMap, AccessRulesConfigMap))
+def test_config_map_update(
+    lk_client: MagicMock, cls: ConfigMapBase, mocked_charm: MagicMock
+) -> None:
+    data = {"a": 1}
+    cm = cls(lk_client, mocked_charm)
+
+    cm.update(data)
+
+    assert lk_client.replace.call_args[0][0].data == data
+
+
+@pytest.mark.parametrize("cls", (OathkeeperConfigMap, AccessRulesConfigMap))
+def test_config_map_patch(
+    lk_client: MagicMock, cls: ConfigMapBase, mocked_charm: MagicMock
+) -> None:
+    patch = {"data": {"a": 1}}
+    cm = cls(lk_client, mocked_charm)
+
+    cm.patch(patch, "cm-name")
+
+    assert lk_client.patch.called
+    assert lk_client.patch.call_args[1]["obj"] == patch
+
+
+@pytest.mark.parametrize("cls", (OathkeeperConfigMap, AccessRulesConfigMap))
+def test_config_map_pop_data(
+    lk_client: MagicMock,
+    cls: ConfigMapBase,
+    mocked_charm: MagicMock,
+) -> None:
+    cm = cls(lk_client, mocked_charm)
+
+    cm.pop_data(keys=["some-key"])
+
+    assert lk_client.replace.called
+
+
+@pytest.mark.parametrize("cls", (OathkeeperConfigMap, AccessRulesConfigMap))
+def test_update_map_error(
+    lk_client: MagicMock, cls: ConfigMapBase, mocked_charm: MagicMock
+) -> None:
+    data = {"data": 1}
+    resp = Response(status_code=403, json={"message": "Forbidden", "code": 403})
+    lk_client.get.side_effect = ApiError(response=resp)
+    cm = cls(lk_client, mocked_charm)
+
+    cm.update(data)
+
+    assert lk_client.get.called
+    assert not lk_client.replace.called
+
+
+@pytest.mark.parametrize("cls", (OathkeeperConfigMap, AccessRulesConfigMap))
+def test_config_map_get(lk_client: MagicMock, cls: ConfigMapBase, mocked_charm: MagicMock) -> None:
+    cm = cls(lk_client, mocked_charm)
+
+    cm.get()
+
+    assert lk_client.get.called
+
+
+@pytest.mark.parametrize("cls", (OathkeeperConfigMap, AccessRulesConfigMap))
+def test_get_map_error(lk_client: MagicMock, cls: ConfigMapBase, mocked_charm: MagicMock) -> None:
+    resp = Response(status_code=403, json={"message": "Forbidden", "code": 403})
+    lk_client.get.side_effect = ApiError(response=resp)
+    cm = cls(lk_client, mocked_charm)
+
+    d = cm.get()
+
+    assert lk_client.get.called
+    assert d == {}
+
+
+@pytest.mark.parametrize("cls", (OathkeeperConfigMap, AccessRulesConfigMap))
+def test_config_map_delete(
+    lk_client: MagicMock,
+    cls: ConfigMapBase,
+    mocked_charm: MagicMock,
+) -> None:
+    cm = cls(lk_client, mocked_charm)
+
+    cm.delete()
+
+    assert lk_client.delete.called
+
+
+@pytest.mark.parametrize("cls", (OathkeeperConfigMap, AccessRulesConfigMap))
+def test_delete_map_error(
+    lk_client: MagicMock, cls: ConfigMapBase, mocked_charm: MagicMock
+) -> None:
+    resp = Response(status_code=403, json={"message": "Forbidden", "code": 403})
+    lk_client.delete.side_effect = ApiError(response=resp)
+    cm = cls(lk_client, mocked_charm)
+
+    with pytest.raises(ValueError):
+        cm.delete()


### PR DESCRIPTION
In order to test this PR:
1. Pack and deploy the charm:
```
charmcraft pack
juju deploy ./oathkeeper*.charm --resource oci-image=$(yq eval '.resources.oci-image.upstream-source' metadata.yaml)
```
2. Wait for the charm to get active, then get the configMap for oathkeeper config:
```
kubectl get cm -n <namespace> oathkeeper-config -o yaml
```
The `access-rules` configmap should be created, but without rules data.
3. Deploy a charm that is able to relate with oathkeeper via `auth-proxy` (for example, zinc-k8s from [this](https://github.com/natalian98/zinc-k8s-operator/tree/test-proxy-interfaces) branch):
```
juju deploy ./zinc-k8s*.charm --resource zinc-image=ghcr.io/jnsgruk/zinc:0.4.9 --trust
juju relate oathkeeper zinc-k8s
```
4. Check the `access-rules` configmap:
```
kubectl get cm -n <namespace> access-rules -o yaml
```
Verify that the access rules `repositories` got updated in the config file:
```
juju ssh oathkeeper/0 "PYTHONPATH=agents/unit-oathkeeper-0/charm/venv/ python3 -c '
from ops import pebble
p = pebble.Client(\"/charm/containers/oathkeeper/pebble.socket\")
f = p.pull(\"/etc/config/oathkeeper/oathkeeper.yaml\")
print(f.read())
'"
```
or run `juju run oathkeeper/0 list-rules`.
You can also deploy traefik and relate it to zinc to verify that the access rules get updated.
5. Run `juju remove-relation oathkeeper zinc-k8s` and check the `access-rules` configmap to see that the rules got removed.