### PR TITLE
fix: correct the regular expressions

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -605,9 +605,10 @@ class OathkeeperCharm(CharmBase):
                 if not allowed_endpoints:
                     return None
                 for endpoint in allowed_endpoints:
+                    allow_regex = f"{endpoint}((/.*$)|$)"
                     allow_rule = self._rule_template(
                         rule_id=f"{relation_app_name}:{endpoint}:{url_index}:allow",
-                        url=f"{url}/{endpoint}",
+                        url=f"{url}/{allow_regex}",
                         authenticator="noop",
                         mutator="noop",
                         error_handler="json",
@@ -618,7 +619,9 @@ class OathkeeperCharm(CharmBase):
             if rule_type == "deny":
                 if allowed_endpoints:
                     # Render a regex to exclude allowed endpoints
-                    exclude_endpoints = ["/" + endpoint + "$" for endpoint in allowed_endpoints]
+                    exclude_endpoints = [
+                        "/" + endpoint + "((/.*$)|$)" for endpoint in allowed_endpoints
+                    ]
 
                     # Add | alternation
                     deny_regex = f"{url}<(?!{'|'.join(exclude_endpoints)}).*>"

--- a/src/charm.py
+++ b/src/charm.py
@@ -605,10 +605,10 @@ class OathkeeperCharm(CharmBase):
                 if not allowed_endpoints:
                     return None
                 for endpoint in allowed_endpoints:
-                    allow_regex = f"{endpoint}((/.*$)|$)"
+                    allow_regex = f"{url}/<{endpoint}((/.*$)|$)>"
                     allow_rule = self._rule_template(
                         rule_id=f"{relation_app_name}:{endpoint}:{url_index}:allow",
-                        url=f"{url}/{allow_regex}",
+                        url=allow_regex,
                         authenticator="noop",
                         mutator="noop",
                         error_handler="json",

--- a/src/charm.py
+++ b/src/charm.py
@@ -618,13 +618,13 @@ class OathkeeperCharm(CharmBase):
             if rule_type == "deny":
                 if allowed_endpoints:
                     # Render a regex to exclude allowed endpoints
-                    exclude_endpoints = [endpoint + "$" for endpoint in allowed_endpoints]
+                    exclude_endpoints = ["/" + endpoint + "$" for endpoint in allowed_endpoints]
 
                     # Add | alternation
-                    deny_regex = f"{url}/<(?!{'|'.join(exclude_endpoints)}).*>"
+                    deny_regex = f"{url}<(?!{'|'.join(exclude_endpoints)}).*>"
                 else:
                     # Protect all endpoints
-                    deny_regex = f"{url}/<.*>"
+                    deny_regex = f"{url}<.*>"
 
                 deny_rule = self._rule_template(
                     rule_id=f"{relation_app_name}:{url_index}:deny",

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -528,7 +528,7 @@ def test_deny_access_rules_rendering_when_single_protected_url_provided(
         {
             "id": f"{app_name}:0:deny",
             "match": {
-                "url": "<^(https|http)>://example.com/<(?!welcome$|about/app$).*>",
+                "url": "<^(https|http)>://example.com<(?!/welcome$|/about/app$).*>",
                 "methods": ["GET", "POST", "OPTION", "PUT", "PATCH", "DELETE"],
             },
             "authenticators": [{"handler": "cookie_session"}],
@@ -565,7 +565,7 @@ def test_deny_access_rules_rendering_when_multiple_protected_urls_provided(
         {
             "id": f"{app_name}:0:deny",
             "match": {
-                "url": "<^(https|http)>://example.com/unit-0/<(?!welcome$|about/app$).*>",
+                "url": "<^(https|http)>://example.com/unit-0<(?!/welcome$|/about/app$).*>",
                 "methods": ["GET", "POST", "OPTION", "PUT", "PATCH", "DELETE"],
             },
             "authenticators": [{"handler": "cookie_session"}],
@@ -576,7 +576,7 @@ def test_deny_access_rules_rendering_when_multiple_protected_urls_provided(
         {
             "id": f"{app_name}:1:deny",
             "match": {
-                "url": "<^(https|http)>://example.com/unit-1/<(?!welcome$|about/app$).*>",
+                "url": "<^(https|http)>://example.com/unit-1<(?!/welcome$|/about/app$).*>",
                 "methods": ["GET", "POST", "OPTION", "PUT", "PATCH", "DELETE"],
             },
             "authenticators": [{"handler": "cookie_session"}],
@@ -605,7 +605,7 @@ def test_all_endpoints_protected_when_no_allowed_endpoints_provided(
         {
             "id": f"{app_name}:0:deny",
             "match": {
-                "url": "<^(https|http)>://example.com/<.*>",
+                "url": "<^(https|http)>://example.com<.*>",
                 "methods": ["GET", "POST", "OPTION", "PUT", "PATCH", "DELETE"],
             },
             "authenticators": [{"handler": "cookie_session"}],

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -423,7 +423,7 @@ def test_allow_access_rules_rendering(
         {
             "id": f"{app_name}:welcome:0:allow",
             "match": {
-                "url": "<^(https|http)>://example.com/welcome",
+                "url": "<^(https|http)>://example.com/welcome((/.*$)|$)",
                 "methods": ["GET", "POST", "OPTION", "PUT", "PATCH", "DELETE"],
             },
             "authenticators": [{"handler": "noop"}],
@@ -434,7 +434,7 @@ def test_allow_access_rules_rendering(
         {
             "id": f"{app_name}:about/app:0:allow",
             "match": {
-                "url": "<^(https|http)>://example.com/about/app",
+                "url": "<^(https|http)>://example.com/about/app((/.*$)|$)",
                 "methods": ["GET", "POST", "OPTION", "PUT", "PATCH", "DELETE"],
             },
             "authenticators": [{"handler": "noop"}],
@@ -488,7 +488,7 @@ def test_allow_access_rules_rendering_when_auth_proxy_config_changed(
         {
             "id": f"{app_name}:welcome:0:allow",
             "match": {
-                "url": "<^(https|http)>://example.com/welcome",
+                "url": "<^(https|http)>://example.com/welcome((/.*$)|$)",
                 "methods": ["GET", "POST", "OPTION", "PUT", "PATCH", "DELETE"],
             },
             "authenticators": [{"handler": "noop"}],
@@ -499,7 +499,7 @@ def test_allow_access_rules_rendering_when_auth_proxy_config_changed(
         {
             "id": f"{app_name}:welcome:1:allow",
             "match": {
-                "url": "<^(https|http)>://other-example.com/welcome",
+                "url": "<^(https|http)>://other-example.com/welcome((/.*$)|$)",
                 "methods": ["GET", "POST", "OPTION", "PUT", "PATCH", "DELETE"],
             },
             "authenticators": [{"handler": "noop"}],
@@ -528,7 +528,7 @@ def test_deny_access_rules_rendering_when_single_protected_url_provided(
         {
             "id": f"{app_name}:0:deny",
             "match": {
-                "url": "<^(https|http)>://example.com<(?!/welcome$|/about/app$).*>",
+                "url": "<^(https|http)>://example.com<(?!/welcome((/.*$)|$)|/about/app((/.*$)|$)).*>",
                 "methods": ["GET", "POST", "OPTION", "PUT", "PATCH", "DELETE"],
             },
             "authenticators": [{"handler": "cookie_session"}],
@@ -565,7 +565,7 @@ def test_deny_access_rules_rendering_when_multiple_protected_urls_provided(
         {
             "id": f"{app_name}:0:deny",
             "match": {
-                "url": "<^(https|http)>://example.com/unit-0<(?!/welcome$|/about/app$).*>",
+                "url": "<^(https|http)>://example.com/unit-0<(?!/welcome((/.*$)|$)|/about/app((/.*$)|$)).*>",
                 "methods": ["GET", "POST", "OPTION", "PUT", "PATCH", "DELETE"],
             },
             "authenticators": [{"handler": "cookie_session"}],
@@ -576,7 +576,7 @@ def test_deny_access_rules_rendering_when_multiple_protected_urls_provided(
         {
             "id": f"{app_name}:1:deny",
             "match": {
-                "url": "<^(https|http)>://example.com/unit-1<(?!/welcome$|/about/app$).*>",
+                "url": "<^(https|http)>://example.com/unit-1<(?!/welcome((/.*$)|$)|/about/app((/.*$)|$)).*>",
                 "methods": ["GET", "POST", "OPTION", "PUT", "PATCH", "DELETE"],
             },
             "authenticators": [{"handler": "cookie_session"}],

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -423,7 +423,7 @@ def test_allow_access_rules_rendering(
         {
             "id": f"{app_name}:welcome:0:allow",
             "match": {
-                "url": "<^(https|http)>://example.com/welcome((/.*$)|$)",
+                "url": "<^(https|http)>://example.com/<welcome((/.*$)|$)>",
                 "methods": ["GET", "POST", "OPTION", "PUT", "PATCH", "DELETE"],
             },
             "authenticators": [{"handler": "noop"}],
@@ -434,7 +434,7 @@ def test_allow_access_rules_rendering(
         {
             "id": f"{app_name}:about/app:0:allow",
             "match": {
-                "url": "<^(https|http)>://example.com/about/app((/.*$)|$)",
+                "url": "<^(https|http)>://example.com/<about/app((/.*$)|$)>",
                 "methods": ["GET", "POST", "OPTION", "PUT", "PATCH", "DELETE"],
             },
             "authenticators": [{"handler": "noop"}],
@@ -488,7 +488,7 @@ def test_allow_access_rules_rendering_when_auth_proxy_config_changed(
         {
             "id": f"{app_name}:welcome:0:allow",
             "match": {
-                "url": "<^(https|http)>://example.com/welcome((/.*$)|$)",
+                "url": "<^(https|http)>://example.com/<welcome((/.*$)|$)>",
                 "methods": ["GET", "POST", "OPTION", "PUT", "PATCH", "DELETE"],
             },
             "authenticators": [{"handler": "noop"}],
@@ -499,7 +499,7 @@ def test_allow_access_rules_rendering_when_auth_proxy_config_changed(
         {
             "id": f"{app_name}:welcome:1:allow",
             "match": {
-                "url": "<^(https|http)>://other-example.com/welcome((/.*$)|$)",
+                "url": "<^(https|http)>://other-example.com/<welcome((/.*$)|$)>",
                 "methods": ["GET", "POST", "OPTION", "PUT", "PATCH", "DELETE"],
             },
             "authenticators": [{"handler": "noop"}],


### PR DESCRIPTION
This PR tries to fix oathkeeper rules not handling urls with trailing slashes.
The "deny" regex should match everything except for the allowed endpoints.

You can quickly check it with https://regex101.com/
```
# deny regex
^(https|http):\/\/example.com(?!\/welcome((\/.*$)|$)|\/about\/app((\/.*$)|$)).*

# will match the first 3
https://example.com/about/
https://example.com/
https://example.com
https://example.com/about/app
https://example.com/welcome
https://example.com/about/app/
https://example.com/welcome/
```
With the previous regex, the third url is not matched, while the last two are. Both cases are incorrect.

```
# allow regex
^(https|http):\/\/example.com\/welcome((\/.*$)|$)

# will match both
https://example.com/welcome
https://example.com/welcome/
```
With the previous regex, only the first one is matched