### PR TITLE
feat: add oathkeeper-info interface

### DIFF
--- a/lib/charms/oathkeeper/v0/oathkeeper_info.py
+++ b/lib/charms/oathkeeper/v0/oathkeeper_info.py
@@ -117,7 +117,7 @@ class OathkeeperInfoProvider(Object):
             logger.info("No relation data available.")
             return None
 
-        return data["access_rules_file"]
+        return data.get("access_rules_file")
 
 
 class OathkeeperInfoRelationError(Exception):

--- a/lib/charms/oathkeeper/v0/oathkeeper_info.py
+++ b/lib/charms/oathkeeper/v0/oathkeeper_info.py
@@ -1,0 +1,194 @@
+#!/usr/bin/env python3
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Interface library for sharing oathkeeper info.
+
+This library provides a Python API for both requesting and providing oathkeeper deployment info,
+such as endpoints, namespace and ConfigMap details.
+## Getting Started
+To get started using the library, you need to fetch the library using `charmcraft`.
+```shell
+cd some-charm
+charmcraft fetch-lib charms.oathkeeper.v0.oathkeeper_info
+```
+To use the library from the requirer side:
+In the `metadata.yaml` of the charm, add the following:
+```yaml
+requires:
+  oathkeeper-info:
+    interface: oathkeeper_info
+    limit: 1
+```
+Then, to initialise the library:
+```python
+from charms.oathkeeper.v0.oathkeeper_info import OathkeeperInfoRequirer
+Class SomeCharm(CharmBase):
+    def __init__(self, *args):
+        self.oathkeeper_info_relation = OathkeeperInfoRequirer(self)
+        self.framework.observe(self.on.some_event_emitted, self.some_event_function)
+    def some_event_function():
+        # fetch the relation info
+        if self.oathkeeper_info_relation.is_ready():
+            oathkeeper_data = self.oathkeeper_info_relation.get_oathkeeper_info()
+```
+"""
+
+import logging
+from typing import Dict, Optional
+
+from ops.charm import CharmBase, RelationCreatedEvent
+from ops.framework import EventBase, EventSource, Object, ObjectEvents
+
+# The unique Charmhub library identifier, never change it
+LIBID = "c801a227f45b46099d7f87cff2dc6e39"
+
+# Increment this major API version when introducing breaking changes
+LIBAPI = 0
+
+# Increment this PATCH version before using `charmcraft publish-lib` or reset
+# to 0 if you are raising the major API version
+LIBPATCH = 1
+
+RELATION_NAME = "oathkeeper-info"
+INTERFACE_NAME = "oathkeeper_info"
+logger = logging.getLogger(__name__)
+
+
+class OathkeeperInfoRelationReadyEvent(EventBase):
+    """Event to notify the charm that the relation is ready."""
+
+
+class OathkeeperInfoProviderEvents(ObjectEvents):
+    """Event descriptor for events raised by `OathkeeperInfoProvider`."""
+
+    ready = EventSource(OathkeeperInfoRelationReadyEvent)
+
+
+class OathkeeperInfoProvider(Object):
+    """Provider side of the oathkeeper-info relation."""
+
+    on = OathkeeperInfoProviderEvents()
+
+    def __init__(self, charm: CharmBase, relation_name: str = RELATION_NAME):
+        super().__init__(charm, relation_name)
+
+        self._charm = charm
+        self._relation_name = relation_name
+
+        events = self._charm.on[relation_name]
+        self.framework.observe(events.relation_created, self._on_info_provider_relation_created)
+
+    def _on_info_provider_relation_created(self, event: RelationCreatedEvent) -> None:
+        self.on.ready.emit()
+
+    def send_info_relation_data(
+        self,
+        public_endpoint: str,
+        rules_configmap_name: str,
+        configmaps_namespace: str,
+    ) -> None:
+        """Updates relation with endpoints and configmaps info."""
+        if not self._charm.unit.is_leader():
+            return
+
+        relations = self.model.relations[self._relation_name]
+        info_databag = {
+            "public_endpoint": public_endpoint,
+            "rules_configmap_name": rules_configmap_name,
+            "configmaps_namespace": configmaps_namespace,
+        }
+
+        for relation in relations:
+            relation.data[self._charm.app].update(info_databag)
+
+    def get_requirer_info(self) -> Optional[str]:
+        """Get the requirer info."""
+        info = self.model.relations[self._relation_name]
+        if len(info) == 0:
+            return None
+
+        if not (app := info[0].app):
+            return None
+
+        data = info[0].data[app]
+
+        if not data:
+            logger.info("No relation data available.")
+            return None
+
+        return data["access_rules_file"]
+
+
+class OathkeeperInfoRelationError(Exception):
+    """Base class for the relation exceptions."""
+
+    pass
+
+
+class OathkeeperInfoRelationMissingError(OathkeeperInfoRelationError):
+    """Raised when the relation is missing."""
+
+    def __init__(self) -> None:
+        self.message = "Missing oathkeeper-info relation with oathkeeper"
+        super().__init__(self.message)
+
+
+class OathkeeperInfoRelationDataMissingError(OathkeeperInfoRelationError):
+    """Raised when information is missing from the relation."""
+
+    def __init__(self, message: str) -> None:
+        self.message = message
+        super().__init__(self.message)
+
+
+class OathkeeperInfoRequirer(Object):
+    """Requirer side of the oathkeeper-info relation."""
+
+    def __init__(self, charm: CharmBase, relation_name: str = RELATION_NAME):
+        super().__init__(charm, relation_name)
+        self._charm = charm
+        self._relation_name = relation_name
+
+    def update_requirer_info_relation_data(
+        self,
+        access_rules_file: str,
+    ) -> None:
+        """Updates relation with access rules info."""
+        if not self._charm.unit.is_leader():
+            return
+
+        relations = self.model.relations[self._relation_name]
+        info_databag = {
+            "access_rules_file": access_rules_file,
+        }
+
+        for relation in relations:
+            relation.data[self._charm.app].update(info_databag)
+
+    def is_ready(self) -> bool:
+        """Checks whether the relation data is ready.
+
+        Returns True when Oathkeeper shared the config; False otherwise.
+        """
+        relation = self.model.get_relation(self._relation_name)
+        if not relation or not relation.app or not relation.data[relation.app]:
+            return False
+        return True
+
+    def get_oathkeeper_info(self) -> Optional[Dict]:
+        """Get the oathkeeper info."""
+        info = self.model.relations[self._relation_name]
+        if len(info) == 0:
+            raise OathkeeperInfoRelationMissingError()
+
+        if not (app := info[0].app):
+            raise OathkeeperInfoRelationMissingError()
+
+        data = info[0].data[app]
+
+        if not data:
+            logger.info("No relation data available.")
+            raise OathkeeperInfoRelationDataMissingError("Missing relation data")
+
+        return data

--- a/lib/charms/oathkeeper/v0/oathkeeper_info.py
+++ b/lib/charms/oathkeeper/v0/oathkeeper_info.py
@@ -37,7 +37,7 @@ Class SomeCharm(CharmBase):
 import logging
 from typing import Dict, Optional
 
-from ops.charm import CharmBase, RelationCreatedEvent
+from ops.charm import CharmBase, RelationChangedEvent
 from ops.framework import EventBase, EventSource, Object, ObjectEvents
 
 # The unique Charmhub library identifier, never change it
@@ -55,14 +55,14 @@ INTERFACE_NAME = "oathkeeper_info"
 logger = logging.getLogger(__name__)
 
 
-class OathkeeperInfoRelationReadyEvent(EventBase):
-    """Event to notify the charm that the relation is ready."""
+class OathkeeperInfoRelationChangedEvent(EventBase):
+    """Event to notify the charm that the relation data has changed."""
 
 
 class OathkeeperInfoProviderEvents(ObjectEvents):
     """Event descriptor for events raised by `OathkeeperInfoProvider`."""
 
-    ready = EventSource(OathkeeperInfoRelationReadyEvent)
+    data_changed = EventSource(OathkeeperInfoRelationChangedEvent)
 
 
 class OathkeeperInfoProvider(Object):
@@ -77,10 +77,10 @@ class OathkeeperInfoProvider(Object):
         self._relation_name = relation_name
 
         events = self._charm.on[relation_name]
-        self.framework.observe(events.relation_created, self._on_info_provider_relation_created)
+        self.framework.observe(events.relation_changed, self._on_info_provider_relation_changed)
 
-    def _on_info_provider_relation_created(self, event: RelationCreatedEvent) -> None:
-        self.on.ready.emit()
+    def _on_info_provider_relation_changed(self, event: RelationChangedEvent) -> None:
+        self.on.data_changed.emit()
 
     def send_info_relation_data(
         self,

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -22,6 +22,10 @@ provides:
     interface: auth_proxy
   forward-auth:
     interface: forward_auth
+  oathkeeper-info:
+    interface: oathkeeper_info
+    description: |
+      Provides oathkeeper deployment info to a related application
 requires:
   kratos-endpoint-info:
     interface: kratos_endpoints

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ profile = "black"
 max-line-length = 99
 max-doc-length = 99
 max-complexity = 10
-exclude = [".git", "__pycache__", ".tox", "build", "dist", "*.egg_info", "venv"]
+exclude = [".git", "__pycache__", ".tox", "build", "dist", "*.egg_info", "venv", "tests/unit/capture_events.py"]
 select = ["E", "W", "F", "C", "N", "R", "D", "H"]
 # Ignore W503, E501 because using black creates errors with this
 # Ignore D107 Missing docstring in __init__

--- a/src/charm.py
+++ b/src/charm.py
@@ -435,6 +435,11 @@ class OathkeeperCharm(CharmBase):
     def _on_oathkeeper_info_relation_ready(
         self, event: OathkeeperInfoRelationCreatedEvent
     ) -> None:
+        if not self._container.can_connect():
+            logger.info(f"Cannot connect to Oathkeeper container. Deferring the {event} event.")
+            event.defer()
+            return
+
         if not self._container.exists("/etc/config/access-rules/admin_ui_rules.json"):
             # Create an empty configMap key for admin ui
             # to make sure it will be enlisted in oathkeeper config

--- a/src/charm.py
+++ b/src/charm.py
@@ -278,8 +278,6 @@ class OathkeeperCharm(CharmBase):
         if cm_access_rules := self.access_rules_configmap.get():
             for key in cm_access_rules.keys():
                 repositories.append(f"{self._access_rules_dir_path}/{key}")
-        if admin_ui_access_rules_file := self.info_provider.get_requirer_info():
-            repositories.append(admin_ui_access_rules_file)
         return repositories
 
     def _render_conf_file(self) -> str:

--- a/src/charm.py
+++ b/src/charm.py
@@ -29,7 +29,10 @@ from charms.oathkeeper.v0.forward_auth import (
     ForwardAuthRelationRemovedEvent,
     InvalidForwardAuthConfigEvent,
 )
-from charms.oathkeeper.v0.oathkeeper_info import OathkeeperInfoProvider
+from charms.oathkeeper.v0.oathkeeper_info import (
+    OathkeeperInfoProvider,
+    OathkeeperInfoRelationChangedEvent,
+)
 from charms.observability_libs.v0.cert_handler import CertChanged, CertHandler
 from charms.observability_libs.v0.kubernetes_service_patch import KubernetesServicePatch
 from charms.traefik_k8s.v2.ingress import (
@@ -163,7 +166,7 @@ class OathkeeperCharm(CharmBase):
         )
 
         self.framework.observe(
-            self.info_provider.on.ready, self._update_oathkeeper_info_relation_data
+            self.info_provider.on.data_changed, self._on_oathkeeper_info_relation_changed
         )
 
         self.framework.observe(self.cert_handler.on.cert_changed, self._on_cert_changed)
@@ -429,6 +432,12 @@ class OathkeeperCharm(CharmBase):
         config_map.delete_all()
 
     def _on_kratos_relation_changed(self, event: RelationChangedEvent) -> None:
+        self._handle_status_update_config(event)
+
+    def _on_oathkeeper_info_relation_changed(
+        self, event: OathkeeperInfoRelationChangedEvent
+    ) -> None:
+        self._update_oathkeeper_info_relation_data(event)
         self._handle_status_update_config(event)
 
     def _on_ingress_ready(self, event: IngressPerAppReadyEvent) -> None:

--- a/tests/unit/capture_events.py
+++ b/tests/unit/capture_events.py
@@ -1,0 +1,85 @@
+"""This is a library providing a utility for unittesting events fired on a
+Harness-ed Charm.
+
+Example usage:
+
+>>> from charms.harness_extensions.v0.capture_events import capture
+>>> with capture(RelationEvent) as captured:
+>>>     harness.add_relation('foo', 'remote')
+>>> assert captured.event.unit.name == 'remote'
+"""
+
+# The unique Charmhub library identifier, never change it
+LIBID = "9fcdab70e26d4eee9797c0e542ab397a"
+
+# Increment this major API version when introducing breaking changes
+LIBAPI = 0
+
+# Increment this PATCH version before using `charmcraft publish-lib` or reset
+# to 0 if you are raising the major API version
+LIBPATCH = 3
+
+# Copyright 2022 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+from contextlib import contextmanager
+from typing import Generic, Iterator, Optional, Type, TypeVar
+
+from ops.charm import CharmBase
+from ops.framework import EventBase
+
+_T = TypeVar("_T", bound=EventBase)
+
+
+@contextmanager
+def capture_events(charm: CharmBase, *types: Type[EventBase]):
+    """Capture all events of type `*types` (using instance checks)."""
+    allowed_types = types or (EventBase,)
+
+    captured = []
+    _real_emit = charm.framework._emit
+
+    def _wrapped_emit(evt):
+        if isinstance(evt, allowed_types):
+            captured.append(evt)
+        return _real_emit(evt)
+
+    charm.framework._emit = _wrapped_emit  # type: ignore # noqa # ugly
+
+    yield captured
+
+    charm.framework._emit = _real_emit  # type: ignore # noqa # ugly
+
+
+class Captured(Generic[_T]):
+    """Object to type and expose return value of capture()."""
+
+    _event = None
+
+    @property
+    def event(self) -> Optional[_T]:
+        """Return the captured event."""
+        return self._event
+
+    @event.setter
+    def event(self, val: _T):
+        self._event = val
+
+
+@contextmanager
+def capture(charm: CharmBase, typ_: Type[_T] = EventBase) -> Iterator[Captured[_T]]:
+    """Capture exactly 1 event of type `typ_`.
+
+    Will raise if more/less events have been fired, or if the returned event
+    does not pass an instance check.
+    """
+    result = Captured()
+    with capture_events(charm, typ_) as captured:
+        if not captured:
+            yield result
+
+    assert len(captured) <= 1, f"too many events captured: {captured}"
+    assert len(captured) >= 1, f"no event of type {typ_} emitted."
+    event = captured[0]
+    assert isinstance(event, typ_), f"expected {typ_}, not {type(event)}"
+    result.event = event

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -48,6 +48,7 @@ def mocked_oathkeeper_configmap(mocker: MockerFixture) -> MagicMock:
 @pytest.fixture(autouse=True)
 def mocked_access_rules_configmap(mocker: MockerFixture) -> MagicMock:
     mock = mocker.patch("charm.AccessRulesConfigMap", autospec=True)
+    mock.return_value.name = "access-rules"
     return mock.return_value
 
 
@@ -115,3 +116,12 @@ def mocked_update_forward_auth(mocker: MockerFixture) -> MagicMock:
         "charms.oathkeeper.v0.forward_auth.ForwardAuthProvider.update_forward_auth_config"
     )
     return mocked_update_forward_auth
+
+
+@pytest.fixture()
+def mocked_oathkeeper_requirer_info(mocker: MockerFixture) -> MagicMock:
+    mocked_oathkeeper_requirer_info = mocker.patch(
+        "charms.oathkeeper.v0.oathkeeper_info.OathkeeperInfoProvider.get_requirer_info"
+    )
+    mocked_oathkeeper_requirer_info.return_value = "requirer-access-rules.json"
+    return mocked_oathkeeper_requirer_info

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -119,9 +119,9 @@ def mocked_update_forward_auth(mocker: MockerFixture) -> MagicMock:
 
 
 @pytest.fixture()
-def mocked_oathkeeper_requirer_info(mocker: MockerFixture) -> MagicMock:
-    mocked_oathkeeper_requirer_info = mocker.patch(
-        "charms.oathkeeper.v0.oathkeeper_info.OathkeeperInfoProvider.get_requirer_info"
+def mocked_oathkeeper_access_rules_list(mocker: MockerFixture) -> MagicMock:
+    mocked_oathkeeper_access_rules_list = mocker.patch(
+        "charm.OathkeeperCharm._get_all_access_rules_repositories"
     )
-    mocked_oathkeeper_requirer_info.return_value = "requirer-access-rules.json"
-    return mocked_oathkeeper_requirer_info
+    mocked_oathkeeper_access_rules_list.return_value = ["requirer-access-rules.json"]
+    return mocked_oathkeeper_access_rules_list

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -9,7 +9,7 @@ from unittest.mock import MagicMock, Mock
 import pytest
 import yaml
 from capture_events import capture_events
-from charms.oathkeeper.v0.oathkeeper_info import OathkeeperInfoRelationReadyEvent
+from charms.oathkeeper.v0.oathkeeper_info import OathkeeperInfoRelationChangedEvent
 from jinja2 import Template
 from ops.model import ActiveStatus, WaitingStatus
 from ops.pebble import ExecError
@@ -61,6 +61,13 @@ def setup_kratos_relation(harness: Harness) -> int:
 def setup_oathkeeper_info_relation(harness: Harness) -> int:
     relation_id = harness.add_relation("oathkeeper-info", "requirer")
     harness.add_relation_unit(relation_id, "requirer/0")
+    harness.update_relation_data(
+        relation_id,
+        "requirer",
+        {
+            "access_rules_file": "requirer-access_rules.json",
+        },
+    )
 
     return relation_id
 
@@ -771,7 +778,7 @@ def test_oathkeeper_info_ready_event_emitted_when_relation_created(harness: Harn
     with capture_events(harness.charm) as captured:
         _ = setup_oathkeeper_info_relation(harness)
 
-    assert any(isinstance(e, OathkeeperInfoRelationReadyEvent) for e in captured)
+    assert any(isinstance(e, OathkeeperInfoRelationChangedEvent) for e in captured)
 
 
 def test_oathkeeper_info_updated_on_relation_ready(harness: Harness) -> None:

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -795,7 +795,7 @@ def test_oathkeeper_info_updated_on_relation_ready(harness: Harness) -> None:
 def test_config_file_includes_oathkeeper_info_requirer_rules(
     harness: Harness,
     mocked_oathkeeper_configmap: MagicMock,
-    mocked_oathkeeper_requirer_info: MagicMock,
+    mocked_oathkeeper_access_rules_list: MagicMock,
 ) -> None:
     harness.set_can_connect(CONTAINER_NAME, True)
     harness.charm.on.oathkeeper_pebble_ready.emit(CONTAINER_NAME)

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -9,7 +9,7 @@ from unittest.mock import MagicMock, Mock
 import pytest
 import yaml
 from capture_events import capture_events
-from charms.oathkeeper.v0.oathkeeper_info import OathkeeperInfoRelationChangedEvent
+from charms.oathkeeper.v0.oathkeeper_info import OathkeeperInfoRelationCreatedEvent
 from jinja2 import Template
 from ops.model import ActiveStatus, WaitingStatus
 from ops.pebble import ExecError
@@ -775,13 +775,15 @@ def test_forward_auth_config_updated_on_tls_set_up(
 
 
 def test_oathkeeper_info_ready_event_emitted_when_relation_created(harness: Harness) -> None:
+    harness.set_can_connect(CONTAINER_NAME, True)
     with capture_events(harness.charm) as captured:
         _ = setup_oathkeeper_info_relation(harness)
 
-    assert any(isinstance(e, OathkeeperInfoRelationChangedEvent) for e in captured)
+    assert any(isinstance(e, OathkeeperInfoRelationCreatedEvent) for e in captured)
 
 
 def test_oathkeeper_info_updated_on_relation_ready(harness: Harness) -> None:
+    harness.set_can_connect(CONTAINER_NAME, True)
     harness.charm.info_provider.send_info_relation_data = mocked_handle = Mock(return_value=None)
     _ = setup_oathkeeper_info_relation(harness)
 


### PR DESCRIPTION
This PR adds `oathkeeper-info` interface to share deployment information with other charms.
