### PR TITLE
chore: update expected Pebble plan when using ops 2.10+

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 cryptography
-ops>=2.0.0
+ops>=2.10
 lightkube
 lightkube-models
 jinja2

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -211,6 +211,12 @@ def test_on_pebble_ready_correct_plan(harness: Harness) -> None:
     harness.charm.on.oathkeeper_pebble_ready.emit(container)
 
     expected_plan = {
+        "checks": {
+            "alive": {
+                "http": {"url": 'http://localhost:4456/health/alive'},
+                "override": "replace",
+            },
+        },
         "services": {
             SERVICE_NAME: {
                 "override": "replace",


### PR DESCRIPTION
- [x] I have signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [x] I am following the [CONTRIBUTING](../CONTRIBUTING.md) guidelines.

<!-- For any questions, ping the @canonical/identity team or post a message in IAM [Mattermost](https://chat.charmhub.io/charmhub/channels/iam-platform) channel. -->

---

<!--
If this pull request

1. fixes a bug: add `fix:` to the PR title
2. implements a new feature: add `feat:`
3. refactors the existing code: add `refactor`
4. updates code formatting or styling: add `style`
5. expands tests: add `test`
6. adds documentation: add `docs`
7. updates a library, workflow, requirements: `chore`
--->

<!-- Fill out the sections that apply -->

## Issue
<!-- What issue is this PR trying to solve? -->

From ops 2.10, `Harness` includes the `checks` in the returned Pebble plan (as is the case in production when actually using Pebble). This means that the unit tests fail against ops 2.10+.

## Solution
<!-- A summary of the solution addressing the above issue -->

Adjust the expected plan in the unit test to match the one that is returned both (now) in production and in testing.

## Additional context
<!-- What is some specialized knowledge relevant to this project/technology -->

I've also bumped the pinned version to be 2.10+ onwards - otherwise the tests should technically handle both cases since the dependency constraint could be satisfied by an older version. Since 2.10 was accepted previously, I'm assuming that this is otherwise ok. There are also some versions after 2.0 (the previous pinned version) where the tests don't pass for other reasons, so I think that it wasn't actually compatible going back that far any more.

## Testing Instructions
<!-- What steps need to be taken to test this PR? -->

Run tests against ops 2.9 and 2.10.

## Release Notes
<!-- A digestable summary of the changes in this PR -->

Fixes tests to run under ops 2.10+.