### PR TITLE
feat: support user email and name custom headers

### DIFF
--- a/integration-requirements.txt
+++ b/integration-requirements.txt
@@ -1,5 +1,5 @@
 protobuf~=3.20.1
 pytest
-juju
+juju==3.3.0.0
 pytest-operator==0.31.1
 -r requirements.txt

--- a/lib/charms/oathkeeper/v0/auth_proxy.py
+++ b/lib/charms/oathkeeper/v0/auth_proxy.py
@@ -78,14 +78,14 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 4
+LIBPATCH = 5
 
 RELATION_NAME = "auth-proxy"
 INTERFACE_NAME = "auth_proxy"
 
 logger = logging.getLogger(__name__)
 
-ALLOWED_HEADERS = ["X-User"]
+ALLOWED_HEADERS = ["X-User", "X-Email", "X-Name"]
 
 url_regex = re.compile(
     r"(^http://)|(^https://)"  # http:// or https://

--- a/templates/oathkeeper.yaml.j2
+++ b/templates/oathkeeper.yaml.j2
@@ -75,3 +75,5 @@ mutators:
     config:
       headers:
         X-User: {% raw %}"{{ print .Subject }}"{% endraw %}
+        X-Email: {% raw %}"{{ print .Extra.identity.traits.email }}"{% endraw %}
+        X-Name: {% raw %}"{{ print .Extra.identity.traits.name }}"{% endraw %}


### PR DESCRIPTION
This PR adds support for new custom headers: `X-Name` and `X-Email`. They are mapped with kratos `identity.traits` claims.