### PR TITLE
fix: include custom headers in template only if requested

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -279,6 +279,7 @@ class OathkeeperCharm(CharmBase):
             kratos_session_url=kratos_endpoints.get("sessions_endpoint", None),
             kratos_login_url=kratos_endpoints.get("login_browser_endpoint", None),
             access_rules=self._get_all_access_rules_repositories(),
+            headers=self.auth_proxy.get_headers(),
         )
         return rendered
 

--- a/templates/oathkeeper.yaml.j2
+++ b/templates/oathkeeper.yaml.j2
@@ -75,5 +75,9 @@ mutators:
     config:
       headers:
         X-User: {% raw %}"{{ print .Subject }}"{% endraw %}
+        {%- if "X-Email" in headers %}
         X-Email: {% raw %}"{{ print .Extra.identity.traits.email }}"{% endraw %}
+        {%- endif %}
+        {%- if "X-Name" in headers %}
         X-Name: {% raw %}"{{ print .Extra.identity.traits.name }}"{% endraw %}
+        {%- endif %}

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -125,3 +125,12 @@ def mocked_oathkeeper_access_rules_list(mocker: MockerFixture) -> MagicMock:
     )
     mocked_oathkeeper_access_rules_list.return_value = ["requirer-access-rules.json"]
     return mocked_oathkeeper_access_rules_list
+
+
+@pytest.fixture()
+def mocked_auth_proxy_headers(mocker: MockerFixture) -> MagicMock:
+    mocked_auth_proxy_headers = mocker.patch(
+        "charms.oathkeeper.v0.auth_proxy.AuthProxyProvider.get_headers",
+        return_value=["X-Name", "X-Email"],
+    )
+    return mocked_auth_proxy_headers

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -221,6 +221,23 @@ def test_update_container_config_with_kratos_relation(
     assert yaml.safe_load(expected_config) == yaml.safe_load(config)
 
 
+def test_container_config_updated_with_custom_headers(
+    harness: Harness, mocked_oathkeeper_configmap: MagicMock, mocked_auth_proxy_headers: MagicMock
+) -> None:
+    harness.set_can_connect(CONTAINER_NAME, True)
+
+    harness.charm.on.oathkeeper_pebble_ready.emit(CONTAINER_NAME)
+
+    with open("templates/oathkeeper.yaml.j2", "r") as file:
+        template = Template(file.read())
+
+    expected_config = template.render(headers=["X-Name", "X-Email"])
+
+    configmap = mocked_oathkeeper_configmap.update.call_args_list[-1][0][0]
+    config = configmap["oathkeeper.yaml"]
+    assert yaml.safe_load(expected_config) == yaml.safe_load(config)
+
+
 def test_on_pebble_ready_correct_plan(harness: Harness) -> None:
     harness.set_can_connect(CONTAINER_NAME, True)
     container = harness.model.unit.get_container(CONTAINER_NAME)


### PR DESCRIPTION
The recently added `X-Name` and `X-Email` headers cause issues in processing requests when the `Extra.identity.traits` claims are not returned upon authentication. Oathkeeper returns 500 response when it fails to parse the value of custom headers. This doesn't concern production `auth-proxy` use cases, but breaks a workaround used in traefik tests.

We use `anonymous` authentication handler in an access rule in [this](https://github.com/canonical/traefik-k8s-operator/blob/a0d76993bce8f9ee1845239e35b3f5bc3183b809/tests/integration/test_forward_auth.py#L115) test as a workaround to check return headers without deploying identity platform. To make it work, oathkeeper should not attempt to parse headers that are not sent back by the anonymous handler. Note that eventually the IA proxy only returns headers specified in traefik forward-auth config, but oathkeeper tries to evaluate them anyways.

This PR fixes that by appending the extra headers only if explicitly requested by `auth-proxy`.