### PR TITLE
Add integration tests for `auth-proxy`, `forward-auth` relations and app scaling

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -33,6 +33,7 @@ jobs:
           channel: 1.28-strict/stable
           juju-channel: 3.1
           bootstrap-options: '--agent-version=3.1.0'
+          microk8s-addons: "dns hostpath-storage metallb:10.64.140.43-10.64.140.49"
 
       - name: Run integration tests
         # set a predictable model name so it can be consumed by charm-logdump-action

--- a/src/config_map.py
+++ b/src/config_map.py
@@ -94,7 +94,10 @@ class ConfigMapBase:
             return
 
         for key in keys:
-            cm.data.pop(key)
+            if key in cm.data.keys():
+                cm.data.pop(key)
+            else:
+                logger.info(f"{key} not found in the ConfigMap")
 
         self._client.replace(cm)
 

--- a/src/config_map.py
+++ b/src/config_map.py
@@ -94,9 +94,9 @@ class ConfigMapBase:
             return
 
         for key in keys:
-            if key in cm.data.keys():
+            try:
                 cm.data.pop(key)
-            else:
+            except KeyError:
                 logger.info(f"{key} not found in the ConfigMap")
 
         self._client.replace(cm)

--- a/tests/integration/auth-proxy-requirer/charmcraft.yaml
+++ b/tests/integration/auth-proxy-requirer/charmcraft.yaml
@@ -1,0 +1,17 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+type: charm
+bases:
+  - build-on:
+      - name: "ubuntu"
+        channel: "22.04"
+    run-on:
+      - name: "ubuntu"
+        channel: "22.04"
+parts:
+  charm:
+    charm-binary-python-packages:
+      - jsonschema
+      - ops
+    build-packages:
+      - git

--- a/tests/integration/auth-proxy-requirer/metadata.yaml
+++ b/tests/integration/auth-proxy-requirer/metadata.yaml
@@ -1,0 +1,22 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+name: auth-proxy-requirer
+display-name: auth-proxy-requirer
+description: Auth Proxy Requirer Tester
+summary: Auth Proxy Requirer Tester
+assumes:
+  - k8s-api
+containers:
+  httpbin:
+    resource: oci-image
+resources:
+  oci-image:
+    type: oci-image
+    description: OCI image for IAP Tester container
+    upstream-source: kennethreitz/httpbin
+requires:
+  auth-proxy:
+    interface: auth_proxy
+    limit: 1
+  ingress:
+    interface: ingress

--- a/tests/integration/auth-proxy-requirer/requirements.txt
+++ b/tests/integration/auth-proxy-requirer/requirements.txt
@@ -1,0 +1,2 @@
+jsonschema
+ops

--- a/tests/integration/auth-proxy-requirer/src/charm.py
+++ b/tests/integration/auth-proxy-requirer/src/charm.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+import logging
+
+from charms.oathkeeper.v0.auth_proxy import AuthProxyConfig, AuthProxyRequirer
+from charms.traefik_k8s.v2.ingress import IngressPerAppReadyEvent, IngressPerAppRequirer
+from ops.charm import CharmBase, PebbleReadyEvent
+from ops.main import main
+from ops.model import ActiveStatus
+from ops.pebble import Layer
+
+AUTH_PROXY_ALLOWED_ENDPOINTS = ["anything/allowed"]
+AUTH_PROXY_HEADERS = ["X-User"]
+HTTPBIN_PORT = 80
+
+logger = logging.getLogger(__name__)
+
+
+class AuthProxyRequirerMock(CharmBase):
+    def __init__(self, framework):
+        super().__init__(framework)
+        self._container = self.unit.get_container("httpbin")
+        self._service_name = "httpbin"
+
+        self.ingress = IngressPerAppRequirer(
+            self,
+            host=f"{self.app.name}.{self.model.name}.svc.cluster.local",
+            relation_name="ingress",
+            port=HTTPBIN_PORT,
+            strip_prefix=True,
+        )
+
+        self.auth_proxy_relation_name = "auth-proxy"
+        self.auth_proxy = AuthProxyRequirer(
+            self, self._auth_proxy_config, self.auth_proxy_relation_name
+        )
+
+        self.framework.observe(self.on.httpbin_pebble_ready, self._on_httpbin_pebble_ready)
+        self.framework.observe(self.ingress.on.ready, self._on_ingress_ready)
+
+    @property
+    def _auth_proxy_config(self) -> AuthProxyConfig:
+        return AuthProxyConfig(
+            protected_urls=[
+                self.ingress.url if self.ingress.url is not None else "https://some-test-url.com"
+            ],
+            headers=AUTH_PROXY_HEADERS,
+            allowed_endpoints=AUTH_PROXY_ALLOWED_ENDPOINTS,
+        )
+
+    @property
+    def _httpbin_pebble_layer(self) -> Layer:
+        layer_config = {
+            "summary": "auth-proxy-requirer-mock layer",
+            "description": "pebble config layer for auth-proxy-requirer-mock",
+            "services": {
+                self._service_name: {
+                    "override": "replace",
+                    "summary": "httpbin layer",
+                    "command": "gunicorn -b 0.0.0.0:80 httpbin:app -k gevent",
+                    "startup": "enabled",
+                }
+            },
+        }
+        return Layer(layer_config)
+
+    def _on_httpbin_pebble_ready(self, event: PebbleReadyEvent) -> None:
+        self._container.add_layer("httpbin", self._httpbin_pebble_layer, combine=True)
+        self._container.replan()
+        self.unit.open_port(protocol="tcp", port=HTTPBIN_PORT)
+
+        self.unit.status = ActiveStatus()
+
+    def _on_ingress_ready(self, event: IngressPerAppReadyEvent) -> None:
+        if self.unit.is_leader():
+            logger.info(f"This app's ingress URL: {event.url}")
+        self.auth_proxy.update_auth_proxy_config(auth_proxy_config=self._auth_proxy_config)
+
+
+if __name__ == "__main__":
+    main(AuthProxyRequirerMock)

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -2,13 +2,29 @@
 # See LICENSE file for licensing details.
 
 import os
+import shutil
 
 import pytest
 from lightkube import Client, KubeConfig
 
 KUBECONFIG = os.environ.get("TESTING_KUBECONFIG", "~/.kube/config")
+AUTH_PROXY_REQUIRER = "auth-proxy-requirer"
 
 
 @pytest.fixture(scope="module")
 def client() -> Client:
     return Client(config=KubeConfig.from_file(KUBECONFIG))
+
+
+@pytest.fixture(scope="module")
+def copy_libraries_into_tester_charm() -> None:
+    """Ensure the tester charm has the required libraries."""
+    libraries = [
+        "traefik_k8s/v2/ingress.py",
+        "oathkeeper/v0/auth_proxy.py",
+    ]
+
+    for lib in libraries:
+        install_path = f"tests/integration/{AUTH_PROXY_REQUIRER}/lib/charms/{lib}"
+        os.makedirs(os.path.dirname(install_path), exist_ok=True)
+        shutil.copyfile(f"lib/charms/{lib}", install_path)

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -6,6 +6,7 @@ import shutil
 
 import pytest
 from lightkube import Client, KubeConfig
+from pytest_operator.plugin import OpsTest
 
 KUBECONFIG = os.environ.get("TESTING_KUBECONFIG", "~/.kube/config")
 AUTH_PROXY_REQUIRER = "auth-proxy-requirer"
@@ -14,6 +15,12 @@ AUTH_PROXY_REQUIRER = "auth-proxy-requirer"
 @pytest.fixture(scope="module")
 def client() -> Client:
     return Client(config=KubeConfig.from_file(KUBECONFIG))
+
+
+@pytest.fixture(scope="module")
+def lightkube_client(ops_test: OpsTest) -> Client:
+    lightkube_client = Client(field_manager="oathkeeper", namespace=ops_test.model.name)
+    return lightkube_client
 
 
 @pytest.fixture(scope="module")

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -238,10 +238,8 @@ async def test_oathkeeper_scale_up(ops_test: OpsTest) -> None:
         status="active",
         raise_on_blocked=True,
         timeout=1000,
+        wait_for_active=True,
     )
-
-    assert ops_test.model.applications[APP_NAME].units[0].workload_status == "active"
-    assert ops_test.model.applications[APP_NAME].units[1].workload_status == "active"
 
 
 async def test_oathkeeper_scale_down(ops_test: OpsTest) -> None:
@@ -255,9 +253,8 @@ async def test_oathkeeper_scale_down(ops_test: OpsTest) -> None:
         status="active",
         raise_on_blocked=True,
         timeout=1000,
+        wait_for_active=True,
     )
-
-    assert ops_test.model.applications[APP_NAME].units[0].workload_status == "active"
 
 
 async def test_remove_forward_auth_integration(ops_test: OpsTest) -> None:

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -2,12 +2,19 @@
 # Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 
+import json
 import logging
+from os.path import join
 from pathlib import Path
+from typing import Dict, List
 
 import pytest
+import requests
 import yaml
+from lightkube import Client
+from lightkube.resources.core_v1 import ConfigMap
 from pytest_operator.plugin import OpsTest
+from tenacity import retry, stop_after_attempt, wait_exponential
 
 logger = logging.getLogger(__name__)
 
@@ -28,6 +35,16 @@ async def get_app_address(ops_test: OpsTest, app_name: str) -> str:
     """Get address of an app."""
     status = await ops_test.model.get_status()  # noqa: F821
     return status["applications"][app_name]["public-address"]
+
+
+async def get_reverse_proxy_app_url(
+    ops_test: OpsTest, ingress_app_name: str, app_name: str
+) -> str:
+    """Get the ingress address of an app."""
+    address = await get_app_address(ops_test, ingress_app_name)
+    proxy_app_url = f"http://{address}/{ops_test.model.name}-{app_name}/"
+    logger.debug(f"Retrieved address: {proxy_app_url}")
+    return proxy_app_url
 
 
 @pytest.mark.skip_if_deployed
@@ -85,6 +102,131 @@ async def test_auth_proxy_relation(ops_test: OpsTest, copy_libraries_into_tester
     )
 
 
+@pytest.mark.abort_on_fail
+async def test_forward_auth_relation(ops_test: OpsTest) -> None:
+    """Ensure that oathkeeper is able to provide forward-auth relation."""
+    await ops_test.model.applications[TRAEFIK].set_config(
+        {"enable_experimental_forward_auth": "True"}
+    )
+    await ops_test.model.integrate(f"{TRAEFIK}:experimental-forward-auth", APP_NAME)
+
+    await ops_test.model.wait_for_idle([TRAEFIK, APP_NAME], status="active", timeout=1000)
+
+
+@retry(
+    wait=wait_exponential(multiplier=3, min=1, max=20),
+    stop=stop_after_attempt(20),
+    reraise=True,
+)
+async def test_allowed_forward_auth_url_redirect(ops_test: OpsTest) -> None:
+    """Test that a request hitting a protected application is forwarded by traefik to oathkeeper.
+
+    An allowed request should be performed without authentication.
+    Retry the request to ensure the access rules were populated by oathkeeper.
+    """
+    requirer_url = await get_reverse_proxy_app_url(ops_test, TRAEFIK, AUTH_PROXY_REQUIRER)
+
+    protected_url = join(requirer_url, "anything/allowed")
+
+    resp = requests.get(protected_url, verify=False)
+    assert resp.status_code == 200
+
+
+async def test_protected_forward_auth_url_redirect(ops_test: OpsTest) -> None:
+    """Test reaching a protected url.
+
+    The request should be forwarded by traefik to oathkeeper.
+    An unauthenticated request should then be denied with 401 Unauthorized response.
+    """
+    requirer_url = await get_reverse_proxy_app_url(ops_test, TRAEFIK, AUTH_PROXY_REQUIRER)
+
+    protected_url = join(requirer_url, "anything/deny")
+
+    resp = requests.get(protected_url, verify=False)
+    assert resp.status_code == 401
+
+
+async def test_forward_auth_url_response_headers(
+    ops_test: OpsTest, lightkube_client: Client
+) -> None:
+    """Test that a response mutated by oathkeeper contains expected custom headers."""
+    requirer_url = await get_reverse_proxy_app_url(ops_test, TRAEFIK, AUTH_PROXY_REQUIRER)
+    protected_url = join(requirer_url, "anything/anonymous")
+
+    # Push an anonymous access rule as a workaround to avoid deploying identity-platform bundle
+    anonymous_rule = [
+        {
+            "id": "iap-requirer:anonymous",
+            "match": {
+                "url": protected_url,
+                "methods": ["GET", "POST", "OPTION", "PUT", "PATCH", "DELETE"],
+            },
+            "authenticators": [{"handler": "anonymous"}],
+            "mutators": [{"handler": "header"}],
+            "authorizer": {"handler": "allow"},
+            "errors": [{"handler": "json"}],
+        }
+    ]
+
+    update_access_rules_configmap(ops_test, lightkube_client, rule=anonymous_rule)
+    update_config_configmap(ops_test, lightkube_client)
+
+    assert_anonymous_response(protected_url)
+
+
+@retry(
+    wait=wait_exponential(multiplier=3, min=1, max=20),
+    stop=stop_after_attempt(20),
+    reraise=True,
+)
+def assert_anonymous_response(url: str) -> None:
+    resp = requests.get(url, verify=False)
+    assert resp.status_code == 200
+
+    headers = json.loads(resp.content).get("headers")
+    assert headers["X-User"] == "anonymous"
+
+
+@retry(
+    wait=wait_exponential(multiplier=3, min=1, max=10),
+    stop=stop_after_attempt(5),
+    reraise=True,
+)
+def update_access_rules_configmap(
+    ops_test: OpsTest, lightkube_client: Client, rule: List[Dict]
+) -> None:
+    """Modify the ConfigMap to force access rules update.
+
+    This is a workaround to test response headers without deploying identity-platform bundle.
+    The anonymous authenticator is used only for testing purposes.
+    """
+    cm = lightkube_client.get(ConfigMap, "access-rules", namespace=ops_test.model.name)
+    data = {"access-rules-iap-requirer-anonymous.json": str(rule)}
+    cm.data = data
+    lightkube_client.replace(cm)
+
+
+@retry(
+    wait=wait_exponential(multiplier=3, min=1, max=10),
+    stop=stop_after_attempt(5),
+    reraise=True,
+)
+def update_config_configmap(ops_test: OpsTest, lightkube_client: Client) -> None:
+    """Modify the ConfigMap to force config file update.
+
+    This is required to include the custom anonymous rule.
+    """
+    cm = lightkube_client.get(ConfigMap, name="oathkeeper-config", namespace=ops_test.model.name)
+    cm = yaml.safe_load(cm.data["oathkeeper.yaml"])
+    cm["access_rules"]["repositories"] = [
+        "file://etc/config/access-rules/access-rules-iap-requirer-anonymous.json"
+    ]
+    patch = {"data": {"oathkeeper.yaml": yaml.dump(cm)}}
+    lightkube_client.patch(
+        ConfigMap, name="oathkeeper-config", namespace=ops_test.model.name, obj=patch
+    )
+
+
 async def test_oathkeeper_scale_up(ops_test: OpsTest) -> None:
     """Check that oathkeeper works after it is scaled up."""
     app = ops_test.model.applications[APP_NAME]
@@ -116,6 +258,20 @@ async def test_oathkeeper_scale_down(ops_test: OpsTest) -> None:
     )
 
     assert ops_test.model.applications[APP_NAME].units[0].workload_status == "active"
+
+
+async def test_remove_forward_auth_integration(ops_test: OpsTest) -> None:
+    """Ensure that the forward-auth relation doesn't cause errors on removal."""
+    await ops_test.juju("remove-relation", APP_NAME, f"{TRAEFIK}:experimental-forward-auth")
+
+    await ops_test.model.wait_for_idle([TRAEFIK, APP_NAME], status="active")
+
+
+async def test_remove_auth_proxy_integration(ops_test: OpsTest) -> None:
+    """Ensure that the auth-proxy relation doesn't cause errors on removal."""
+    await ops_test.juju("remove-relation", APP_NAME, f"{AUTH_PROXY_REQUIRER}:auth-proxy")
+
+    await ops_test.model.wait_for_idle([APP_NAME, AUTH_PROXY_REQUIRER], status="active")
 
 
 async def test_list_rules(ops_test: OpsTest) -> None:


### PR DESCRIPTION
This PR adds tests cases for:
- adding and removing `auth-proxy` and `forward-auth` relations provided by oathkeeper
- scaling oathkeeper up and down while integrated with the above
- identity and access proxy (401/200 responses, response headers)