### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/on_schedule.yaml
+++ b/.github/workflows/on_schedule.yaml
@@ -1,3 +1,4 @@
+name: On Schedule
 on:
   schedule:
     - cron: '0 8 * * MON'

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -31,8 +31,7 @@ jobs:
         with:
           provider: microk8s
           channel: 1.28-strict/stable
-          juju-channel: 3.1
-          bootstrap-options: '--agent-version=3.1.0'
+          juju-channel: 3.4
           microk8s-addons: "dns hostpath-storage metallb:10.64.140.43-10.64.140.49"
 
       - name: Run integration tests


### PR DESCRIPTION
Traefik rev194 introduced creation of a LoadBalancer service type instead of modifying traefik's juju ClusterIP.
This broke our CI as the helper for getting traefik public address was fetching it from juju app status, which is no longer valid.

This PR fixes it by retrieving the ip from the lb service.
