### PR TITLE
Fix charm publish action for Ubuntu 24.04

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -53,9 +53,16 @@ jobs:
           echo "setting output of destination_channel=$destination_channel"
           echo "::set-output name=destination_channel::$destination_channel"
 
+      # Required to charmcraft pack in non-destructive mode
+      - name: Setup lxd
+        uses: canonical/setup-lxd@v0.1.2
+        with:
+          channel: latest/stable
+
       - name: Upload charm to charmhub
         uses: canonical/charming-actions/upload-charm@934193396735701141a1decc3613818e412da606 # 2.6.3
         with:
           credentials: ${{ secrets.CHARMCRAFT_CREDENTIALS }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           channel: ${{ steps.parse-inputs.outputs.destination_channel }}
+          destructive-mode: false

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -97,13 +97,9 @@ actions:
         type: string
     required: ["rule-id"]
 
-bases:
-  - build-on:
-      - name: "ubuntu"
-        channel: "22.04"
-    run-on:
-      - name: "ubuntu"
-        channel: "22.04"
+base: ubuntu@22.04
+platforms:
+  amd64:
 
 parts:
   charm:


### PR DESCRIPTION
## Description
Refactor operator to fix publish action for Ubuntu 24.04

## Changes
- set `destructive-mode: false` in publish step of the action
- add step to setup LXD
- edit charmcraft.yaml

Fixes #114 